### PR TITLE
FileReaderDriver returns the device timestamp in GetNextTime

### DIFF
--- a/HAL/Camera/Drivers/FileReader/FileReaderDriver.cpp
+++ b/HAL/Camera/Drivers/FileReader/FileReaderDriver.cpp
@@ -242,7 +242,6 @@ double FileReaderDriver::_GetNextTime() {
   }
   return (m_qImageBuffer.front().has_device_time() ?
           m_qImageBuffer.front().device_time() : 0);
-  // return m_qImageBuffer.front()[0].Map.GetProperty<double>(m_sTimeKeeper, 0);
 }
 
 double FileReaderDriver::_GetTimestamp(const std::string& sFileName) const {


### PR DESCRIPTION
This also solves an issue of threads getting blocked when several
devices (e.g. stereo + imu) use hal::DeviceTime::WaitForTime and
related functions.
