### PR TITLE
Support for 16 and 32 bit images for Convert driver

### DIFF
--- a/HAL/Camera/Drivers/Convert/ConvertDriver.h
+++ b/HAL/Camera/Drivers/Convert/ConvertDriver.h
@@ -12,7 +12,8 @@ class ConvertDriver : public CameraDriverInterface
 {
 public:
     ConvertDriver(std::shared_ptr<CameraDriverInterface> Input,
-                   const std::string& sFormat
+                   const std::string& sFormat,
+                   double dRange
                  );
 
     bool Capture( pb::CameraMsg& vImages );
@@ -32,7 +33,7 @@ protected:
     unsigned int                            m_nImgWidth;
     unsigned int                            m_nImgHeight;
     unsigned int                            m_nNumChannels;
-    double                                  m_dScale;
+    double                                  m_dRange;
 };
 
 }

--- a/HAL/Camera/Drivers/Convert/ConvertFactory.cpp
+++ b/HAL/Camera/Drivers/Convert/ConvertFactory.cpp
@@ -1,6 +1,7 @@
 #include <HAL/Devices/DeviceFactory.h>
 #include "ConvertDriver.h"
 
+#include <cstdlib>
 #include <string>
 
 namespace hal
@@ -13,13 +14,26 @@ public:
     : DeviceFactory<CameraDriverInterface>(name)
   {
     Params() = {
-      {"fmt", "MONO8", "Video format: MONO8, RGB8"}
+      {"fmt", "MONO8", "Video format: MONO8, RGB8"},
+      {"range", "1", "Range of values of 16 and 32 bit images: ir (1023), "
+                     "depth (4500) or numerical value"}
   };
   }
 
   std::shared_ptr<CameraDriverInterface> GetDevice(const Uri& uri)
   {
     std::string sFormat = uri.properties.Get<std::string>("fmt", "MONO8");
+    std::string sRange = uri.properties.Get<std::string>("range", "1");
+    double dRange;
+
+    if(sRange == "ir")
+      dRange = 1023; // OpenNi uses the 10 l.s.bits only (range [0, 1023])
+    else if(sRange == "depth")
+      dRange = 4500; // max range (mm) of asus xtion pro live
+    else {
+      dRange = strtod(sRange.c_str(), nullptr);
+      if(dRange == 0.) dRange = 1.;
+    }
 
     const Uri input_uri = Uri(uri.url);
 
@@ -27,7 +41,7 @@ public:
     std::shared_ptr<CameraDriverInterface> Input =
         DeviceRegistry<hal::CameraDriverInterface>::I().Create(input_uri);
 
-    ConvertDriver* pDriver = new ConvertDriver( Input, sFormat );
+    ConvertDriver* pDriver = new ConvertDriver( Input, sFormat, dRange );
     return std::shared_ptr<CameraDriverInterface>( pDriver );
   }
 };


### PR DESCRIPTION
This fixes a problem w.r.t. the conversion from 16 bit and 32 bit images into 8 bit grayscale.
The PR adds a parameter to set the expected range of values of 16-32 bit images (especially for infrared and depth images)
