### PR TITLE
Several ProtoReader drivers can coexist

### DIFF
--- a/HAL/Camera/Drivers/ProtoReader/ProtoReaderDriver.cpp
+++ b/HAL/Camera/Drivers/ProtoReader/ProtoReaderDriver.cpp
@@ -9,7 +9,7 @@ namespace hal {
 ProtoReaderDriver::ProtoReaderDriver(std::string filename, int camID, size_t imageID)
     : m_first(true),
       m_camId(camID),
-      m_reader( pb::Reader::Instance(filename,pb::Msg_Type_Camera) ) {
+      m_reader(filename) {
   m_reader.SetInitialImage(imageID);
   while( !ReadNextCameraMessage(m_nextMsg) ) {
     std::cout << "HAL: Initializing proto-reader..." << std::endl;

--- a/HAL/Camera/Drivers/ProtoReader/ProtoReaderDriver.h
+++ b/HAL/Camera/Drivers/ProtoReader/ProtoReaderDriver.h
@@ -27,7 +27,7 @@ class ProtoReaderDriver : public CameraDriverInterface {
 
   bool                    m_first;
   int                     m_camId;
-  pb::Reader&             m_reader;
+  pb::Reader              m_reader;
   pb::CameraMsg           m_nextMsg;
 
   std::vector<size_t>     m_width;


### PR DESCRIPTION
When a program created two `CameraDriverInterface` using the ProtoReader driver to read two .log files, both drivers actually shared the same file reader, making both drivers acquire images from just one file. This PR solves that.
