### PR TITLE
Join driver

### DIFF
--- a/HAL/Camera/Drivers/Join/CMakeLists.txt
+++ b/HAL/Camera/Drivers/Join/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_to_hal_sources( JoinDriver.h JoinDriver.cpp JoinFactory.cpp )

--- a/HAL/Camera/Drivers/Join/JoinDriver.cpp
+++ b/HAL/Camera/Drivers/Join/JoinDriver.cpp
@@ -1,0 +1,121 @@
+#include <iostream>
+#include <memory>
+#include <string>
+#include <algorithm>
+#include <thread>
+
+#include <HAL/Devices/DeviceException.h>
+#include <HAL/Utils/TicToc.h>
+
+#include "JoinDriver.h"
+
+using namespace hal;
+
+JoinDriver::JoinDriver(
+    const std::vector<std::shared_ptr<CameraDriverInterface>>& cameras)
+  : m_Cameras(cameras)
+{
+  const size_t N = NumChannels();
+  m_nImgWidth.reserve(N);
+  m_nImgHeight.reserve(N);
+
+  m_nNumChannels = 0;
+  for( auto& cam : m_Cameras ) {
+    for( size_t i = 0; i < cam->NumChannels(); ++i ) {
+      m_nImgWidth.push_back(cam->Width(i));
+      m_nImgHeight.push_back(cam->Height(i));
+    }
+    m_nNumChannels += cam->NumChannels();
+    m_WorkTeam.addWorker(cam);
+  }
+}
+
+JoinDriver::~JoinDriver()
+{
+}
+
+void
+JoinDriver::WorkTeam::addWorker(std::shared_ptr<CameraDriverInterface>& cam)
+{
+  const size_t workerId = m_ImageData.size();
+  {
+    std::unique_lock<std::mutex>(m_Mutex);
+    m_ImageData.push_back(pb::CameraMsg());
+    m_bWorkerDone.push_back(true);
+  }
+  m_Workers.emplace_back(std::thread(&JoinDriver::WorkTeam::Worker, this,
+                                     std::ref(cam), workerId));
+}
+
+void JoinDriver::WorkTeam::Worker(std::shared_ptr<CameraDriverInterface>& cam,
+                                  size_t workerId)
+{
+  for (;;) {
+    waitForWork(workerId);
+    cam->Capture(m_ImageData[workerId]);
+    workerDone(workerId);
+  }
+}
+
+void JoinDriver::WorkTeam::waitForWork(size_t workerId)
+{
+  std::unique_lock<std::mutex> lock(m_Mutex);
+  if( m_bWorkerDone[workerId] ) m_WorkerCond.wait(lock);
+}
+
+void JoinDriver::WorkTeam::workerDone(size_t workerId)
+{
+  std::lock_guard<std::mutex> lock(m_Mutex);
+  m_bWorkerDone[workerId] = true;
+  m_MasterCond.notify_one();
+}
+
+bool JoinDriver::Capture( pb::CameraMsg& vImages )
+{
+  vImages.Clear();
+  const double time = Tic();
+  vImages.set_system_time(time);
+  vImages.set_device_time(time);
+
+  std::vector<pb::CameraMsg>& results = m_WorkTeam.process();
+
+  for( pb::CameraMsg& result : results ) {
+    for( int i = 0; i < result.image_size(); ++i ) {
+      vImages.add_image()->Swap(result.mutable_image(i));
+    }
+    result.Clear();
+  }
+  return true;
+}
+
+std::vector<pb::CameraMsg>& JoinDriver::WorkTeam::process()
+{
+  std::unique_lock<std::mutex> lock(m_Mutex);
+  std::fill(m_bWorkerDone.begin(), m_bWorkerDone.end(), false);
+  m_WorkerCond.notify_all();
+  m_MasterCond.wait(lock, [this]{
+    return std::find(m_bWorkerDone.begin(), m_bWorkerDone.end(), false)
+        == m_bWorkerDone.end();
+  });
+  return m_ImageData;
+}
+
+std::string JoinDriver::GetDeviceProperty(const std::string&)
+{
+  return std::string();
+}
+
+size_t JoinDriver::NumChannels() const
+{
+  return m_nNumChannels;
+}
+
+size_t JoinDriver::Width( size_t idx ) const
+{
+  return m_nImgWidth[idx];
+}
+
+size_t JoinDriver::Height( size_t idx ) const
+{
+  return m_nImgHeight[idx];
+}

--- a/HAL/Camera/Drivers/Join/JoinDriver.h
+++ b/HAL/Camera/Drivers/Join/JoinDriver.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <vector>
+#include <list>
+#include <memory>
+#include <string>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+
+#include "HAL/Camera/CameraDriverInterface.h"
+
+namespace hal {
+
+class JoinDriver : public CameraDriverInterface
+{
+public:
+  JoinDriver(
+      const std::vector<std::shared_ptr<CameraDriverInterface>>& cameras);
+  virtual ~JoinDriver();
+
+  bool Capture( pb::CameraMsg& vImages );
+  std::shared_ptr<CameraDriverInterface> GetInputDevice() {
+    return std::shared_ptr<CameraDriverInterface>();
+  }
+
+  std::string GetDeviceProperty(const std::string& sProperty);
+
+  size_t NumChannels() const;
+  size_t Width( size_t idx = 0 ) const;
+  size_t Height( size_t idx = 0 ) const;
+
+private:
+  std::vector<std::shared_ptr<CameraDriverInterface>> m_Cameras;
+  std::vector<unsigned int> m_nImgWidth;
+  std::vector<unsigned int> m_nImgHeight;
+  unsigned int              m_nNumChannels;
+
+  class WorkTeam
+  {
+  public:
+    WorkTeam(){}
+    void addWorker(std::shared_ptr<CameraDriverInterface>& cam);
+    std::vector<pb::CameraMsg>& process();
+
+  private:
+    void waitForWork(size_t workerId);
+    void workerDone(size_t workerId);
+    void Worker(std::shared_ptr<CameraDriverInterface>& cam,
+                size_t workerId);
+
+  private:
+    std::vector<std::thread> m_Workers;
+    std::vector<bool> m_bWorkerDone;
+    std::vector<pb::CameraMsg> m_ImageData;
+    std::mutex m_Mutex;
+    std::condition_variable m_WorkerCond, m_MasterCond;
+  };
+
+  WorkTeam                  m_WorkTeam;
+
+};
+
+}

--- a/HAL/Camera/Drivers/Join/JoinFactory.cpp
+++ b/HAL/Camera/Drivers/Join/JoinFactory.cpp
@@ -1,0 +1,65 @@
+#include <HAL/Devices/DeviceFactory.h>
+#include "JoinDriver.h"
+
+namespace hal
+{
+
+class JoinFactory : public DeviceFactory<CameraDriverInterface>
+{
+public:
+  JoinFactory(const std::string& name)
+    : DeviceFactory<CameraDriverInterface>(name)
+  {
+    Params() = {};
+  }
+
+  std::shared_ptr<CameraDriverInterface> GetDevice(const Uri& uri)
+  {
+    std::vector<Uri> suburis = splitUri(uri.url);
+    std::vector<std::shared_ptr<CameraDriverInterface>> cameras;
+    cameras.reserve(suburis.size());
+
+    for( const Uri& uri : suburis ) {
+      try {
+        std::cout << "Creating stream from uri: " << uri.ToString()
+                  << std::endl;
+        cameras.emplace_back
+            (DeviceRegistry<hal::CameraDriverInterface>::I().Create(uri));
+      } catch ( std::exception& e ) {
+        throw DeviceException(std::string("Error creating driver from uri \"") +
+                              uri.ToString() + "\": " + e.what());
+      }
+    }
+
+    if( cameras.empty() ) {
+      throw DeviceException("No input cameras given to join");
+    }
+
+    JoinDriver* pDriver = new JoinDriver(cameras);
+    return std::shared_ptr<CameraDriverInterface>( pDriver );
+  }
+
+  std::vector<Uri> splitUri(const std::string& url)
+  {
+    const char C = '&'; // split token
+
+    std::vector<Uri> ret;
+    std::string::size_type begin = 0, end = 0;
+    for(; end != std::string::npos; begin = end + 1 ) {
+      end = url.find( C, begin );
+      std::string s;
+      if( end == std::string::npos )
+        s = url.substr(begin);
+      else
+        s = url.substr(begin, end - begin);
+      if( !s.empty() ) ret.emplace_back( Uri(s) );
+    }
+    return ret;
+  }
+
+};
+
+// Register this factory by creating static instance of factory
+static JoinFactory g_JoinFactory("join");
+
+}

--- a/HAL/Camera/Drivers/Join/README
+++ b/HAL/Camera/Drivers/Join/README
@@ -1,0 +1,12 @@
+The Join driver allows to join image streams from an arbitrary number of other HAL drivers.
+
+Usage:
+	join://<driver1>&<driver2>&...&<driverN>
+
+Example:
+	join://node://client1/images&node://client2/images
+
+Note that if used in the command line you need to escape the character '&' or to write all
+the driver line between quotes. Examples:
+  ./SensorViewer -cam join://node://client1/images\&node://client2/images
+  ./SensorViewer -cam "join://node://client1/images&node://client2/images"


### PR DESCRIPTION
Driver to join images from different streams into a single `pb::CameraMsg` structure. The idea is that we can use all our programs that get a single `-cam` parameter (e.g. vicalib, SensorViewer) without modifications.

Syntax:
`join://<driver1>&<driver2>&...&<driverN>`

Example to join images from a Kinect and a Kinect2 cameras:
`join://openni://&freenect2://`

Note that the `&` must be escaped in the command line.
