### PR TITLE
wait for callback thread

### DIFF
--- a/HAL/IMU/Drivers/ProtoReader/ProtoReaderIMUDriver.cpp
+++ b/HAL/IMU/Drivers/ProtoReader/ProtoReaderIMUDriver.cpp
@@ -38,6 +38,9 @@ ProtoReaderIMUDriver::~ProtoReaderIMUDriver()
 void ProtoReaderIMUDriver::RegisterIMUDataCallback(IMUDriverDataCallback callback)
 {
     m_callback = callback;
-    m_running = true;
-    m_callbackThread = std::thread( &ProtoReaderIMUDriver::_ThreadFunc, this );
+    if( !m_callbackThread.joinable() ) {
+        // start capture thread
+        m_running = true;
+        m_callbackThread = std::thread( &ProtoReaderIMUDriver::_ThreadFunc, this );
+    }
 }


### PR DESCRIPTION
I've checked out the results of using the Protobuf IMU reader without this fix---the ceres-solver does not converge and the GUI doesn't show IMU measurement vectors being added to the camera frames. However, with the changes the ceres-solver does converge.

Note: I'm still not sure of the accuracy of the results; that depends on the relative position of the camera and the IMU, and I'm not sure of the ground truth for the datasets I'm operating on.