### PR TITLE
Sets the system time on the microstrain posys message.

### DIFF
--- a/HAL/IMU/Drivers/MicroStrain/MicroStrainDriver.cpp
+++ b/HAL/IMU/Drivers/MicroStrain/MicroStrainDriver.cpp
@@ -117,6 +117,7 @@ void MicroStrainDriver::CallbackFunc(void* /*user_ptr*/, u8 *packet, u16 /*packe
 
                         // TODO It is probably better to use a differnent time specific for the GPS??
                         pbPoseMsg.set_device_time(curr_ahrs_pps_timestamp.seconds + 1E-9 * curr_ahrs_pps_timestamp.nanoseconds);
+                        pbPoseMsg.set_system_time(hal::Tic());
                     }break;
 
                     // Scaled Accelerometer


### PR DESCRIPTION
The microstrain driver was not setting the system time on the posys message. This is now fixed.