### PR TITLE
miniglog/logging.h was included twice for some reason

### DIFF
--- a/Applications/CamToNode/main.cpp
+++ b/Applications/CamToNode/main.cpp
@@ -10,7 +10,7 @@
 #include <HAL/Camera/CameraDevice.h>
 #include <Node/Node.h>
 #include <PbMsgs/ImageArray.h>
-#include <miniglog/logging.h>
+//#include <miniglog/logging.h>
 
 DEFINE_string(node, "camtonode", "Node name");
 DEFINE_string(topic, "images", "Topic name");


### PR DESCRIPTION
when trying to pull hall it was complaining for :
n file included from /Users/Sina/rpg/CoreDev/HAL/Applications/CamToNode/main.cpp:13:
/Users/Sina/rpg/CoreDev/miniglog/miniglog/logging.h:119:11: error: redefinition of 'INFO'
const int INFO    = ::INFO;
          ^
/usr/local/include/glog/log_severity.h:53:11: note: previous definition is here
const int INFO = GLOG_INFO, WARNING = GLOG_WARNING,
          ^
In file included from /Users/Sina/rpg/CoreDev/HAL/Applications/CamToNode/main.cpp:13:
/Users/Sina/rpg/CoreDev/miniglog/miniglog/logging.h:120:11: error: redefinition of 'WARNING'
const int WARNING = ::WARNING;
          ^
/usr/local/include/glog/log_severity.h:53:29: note: previous definition is here
const int INFO = GLOG_INFO, WARNING = GLOG_WARNING,
                            ^
In file included from /Users/Sina/rpg/CoreDev/HAL/Applications/CamToNode/main.cpp:13:
/Users/Sina/rpg/CoreDev/miniglog/miniglog/logging.h:121:11: error: redefinition of 'ERROR'
const int ERROR   = ::ERROR;
          ^
/usr/local/include/glog/log_severity.h:54:3: note: previous definition is here
  ERROR = GLOG_ERROR, FATAL = GLOG_FATAL;
  ^
In file included from /Users/Sina/rpg/CoreDev/HAL/Applications/CamToNode/main.cpp:13:
/Users/Sina/rpg/CoreDev/miniglog/miniglog/logging.h:122:11: error: redefinition of 'FATAL'
const int FATAL   = ::FATAL;
 
and so on, fixed it by removing logging.h