### PR TITLE
[For CMake 3.2+] CMakeLists.txt for several drivers updated to ignore generated CMakeFiles folders

### DIFF
--- a/HAL/Camera/Drivers/CMakeLists.txt
+++ b/HAL/Camera/Drivers/CMakeLists.txt
@@ -1,7 +1,9 @@
 subdirlist(SUBDIRS ${CMAKE_CURRENT_SOURCE_DIR})
 
 foreach(subdir ${SUBDIRS})
-  add_subdirectory(${subdir})
+  if(NOT("${subdir}" STREQUAL "CMakeFiles"))
+    add_subdirectory(${subdir})
+  endif()
 endforeach()
 
 if(HAL_HAVE_THIRDPARTY)

--- a/HAL/Car/Drivers/CMakeLists.txt
+++ b/HAL/Car/Drivers/CMakeLists.txt
@@ -12,5 +12,7 @@ endmacro()
 subdirlist(SUBDIRS ${CMAKE_CURRENT_SOURCE_DIR})
 
 foreach(subdir ${SUBDIRS})
+  if(NOT("${subdir}" STREQUAL "CMakeFiles"))
     add_subdirectory(${subdir})
+  endif()
 endforeach()

--- a/HAL/Encoder/Drivers/CMakeLists.txt
+++ b/HAL/Encoder/Drivers/CMakeLists.txt
@@ -1,5 +1,9 @@
 subdirlist(SUBDIRS ${CMAKE_CURRENT_SOURCE_DIR})
 
+subdirlist(SUBDIRS ${CMAKE_CURRENT_SOURCE_DIR})
+
 foreach(subdir ${SUBDIRS})
+  if(NOT("${subdir}" STREQUAL "CMakeFiles"))
     add_subdirectory(${subdir})
+  endif()
 endforeach()

--- a/HAL/IMU/Drivers/CMakeLists.txt
+++ b/HAL/IMU/Drivers/CMakeLists.txt
@@ -1,7 +1,9 @@
 subdirlist(SUBDIRS ${CMAKE_CURRENT_SOURCE_DIR})
 
 foreach(subdir ${SUBDIRS})
-  add_subdirectory(${subdir})
+  if(NOT("${subdir}" STREQUAL "CMakeFiles"))
+    add_subdirectory(${subdir})
+  endif()
 endforeach()
 
 if(HAL_HAVE_THIRDPARTY)

--- a/HAL/LIDAR/Drivers/CMakeLists.txt
+++ b/HAL/LIDAR/Drivers/CMakeLists.txt
@@ -1,5 +1,7 @@
 subdirlist(SUBDIRS ${CMAKE_CURRENT_SOURCE_DIR})
 
 foreach(subdir ${SUBDIRS})
+  if(NOT("${subdir}" STREQUAL "CMakeFiles"))
     add_subdirectory(${subdir})
+  endif()
 endforeach()

--- a/HAL/Posys/Drivers/CMakeLists.txt
+++ b/HAL/Posys/Drivers/CMakeLists.txt
@@ -1,5 +1,7 @@
 subdirlist(SUBDIRS ${CMAKE_CURRENT_SOURCE_DIR})
 
 foreach(subdir ${SUBDIRS})
+  if(NOT("${subdir}" STREQUAL "CMakeFiles"))
     add_subdirectory(${subdir})
+  endif()
 endforeach()


### PR DESCRIPTION
It seems like this becomes critical with CMake above a certain version (I have 3.2). CMake generates CMakeFiles folders. When CMake configuration is re-run, these folders get treated as sources (i.e. there is automated directory listing in certain CMakeList.txt files, which indiscriminately adds all subfolders as source folders). CMakeFiles directories, natrually, don't have CMakeLists.txt inside, and CMake will fail to generate with an error having failed to find these.

I've added a simple check to skip over the CMakeLists folders in the relevant CMakeLists.txt files.