### PR TITLE
Temp. hack -- adding depth registration code missing from the latest freenect driver.

### DIFF
--- a/HAL/Camera/Drivers/Freenect2/CMakeLists.txt
+++ b/HAL/Camera/Drivers/Freenect2/CMakeLists.txt
@@ -2,6 +2,10 @@ find_package( freenect2 QUIET )
 
 set( BUILD_Freenect2 "${freenect2_FOUND}" CACHE BOOL
   "Build Freenect2 driver for Kinect2" )
+ 
+set(freenect2_DEFINITIONS "-DLIBFREENECT2_THREADING_TINYTHREAD")
+#temp fix for OpenKinect/libfreenect2 issue #217
+set(freenect2_INCLUDE_DIRS ${freenect2_INCLUDE_DIR} ${freenect2_INCLUDE_DIR}/libfreenect2/tinythread)
 
 if( BUILD_Freenect2 )
     if( freenect2_FOUND )

--- a/HAL/Camera/Drivers/Freenect2/CMakeLists.txt
+++ b/HAL/Camera/Drivers/Freenect2/CMakeLists.txt
@@ -2,7 +2,7 @@ find_package( freenect2 QUIET )
 
 set( BUILD_Freenect2 "${freenect2_FOUND}" CACHE BOOL
   "Build Freenect2 driver for Kinect2" )
- 
+
 set(freenect2_DEFINITIONS "-DLIBFREENECT2_THREADING_TINYTHREAD")
 #temp fix for OpenKinect/libfreenect2 issue #217
 set(freenect2_INCLUDE_DIRS ${freenect2_INCLUDE_DIR} ${freenect2_INCLUDE_DIR}/libfreenect2/tinythread)
@@ -12,7 +12,7 @@ if( BUILD_Freenect2 )
         add_to_hal_include_dirs( ${freenect2_INCLUDE_DIRS} )
         add_to_hal_libraries( ${freenect2_LIBRARY} )
         add_to_hal_sources( Freenect2Driver.h Freenect2Driver.cpp
-          Freenect2Factory.cpp )
+          Freenect2Factory.cpp depth_registration.h depth_registration.cpp depth_registration_cpu.h depth_registration_cpu.cpp)
 	hal_set_compile_flags( ${CMAKE_CURRENT_SOURCE_DIR}/Freenect2Driver.cpp ${freenect2_DEFINITIONS} )
 	hal_set_compile_flags( ${CMAKE_CURRENT_SOURCE_DIR}/Freenect2Factory.cpp ${freenect2_DEFINITIONS} )
     else()

--- a/HAL/Camera/Drivers/Freenect2/Freenect2Driver.cpp
+++ b/HAL/Camera/Drivers/Freenect2/Freenect2Driver.cpp
@@ -19,203 +19,211 @@ using namespace hal;
 const unsigned int Freenect2Driver::IR_IMAGE_WIDTH = 512;
 const unsigned int Freenect2Driver::IR_IMAGE_HEIGHT = 424;
 
-Freenect2Driver::Freenect2Driver(
-    unsigned int            nWidth,
-    unsigned int            nHeight,
-    bool                    bCaptureRGB,
-    bool                    bCaptureDepth,
-    bool                    bCaptureIR,
-    bool                    bColor,
-    bool                    bAlign)
-  : m_nImgWidth(nWidth), m_nImgHeight(nHeight), m_bRGB(bCaptureRGB),
-    m_bDepth(bCaptureDepth), m_bIR(bCaptureIR), m_bColor(bColor),
-    m_bAlign(bAlign)
-{
-  const int N = m_freenect2.enumerateDevices();
-  if(N == 0) {
-    throw DeviceException("Freenect2 could not find any camera");
-  }
+Freenect2Driver::Freenect2Driver(unsigned int nWidth, unsigned int nHeight,
+		bool bCaptureRGB, bool bCaptureDepth, bool bCaptureIR, bool bColor,
+		bool bAlign) :
+				m_nImgWidth(nWidth),
+				m_nImgHeight(nHeight),
+				m_bRGB(bCaptureRGB),
+				m_bDepth(bCaptureDepth),
+				m_bIR(bCaptureIR),
+				m_bColor(bColor),
+				m_bAlign(bAlign) {
+	const int N = m_freenect2.enumerateDevices();
+	if (N == 0) {
+		throw DeviceException("Freenect2 could not find any camera");
+	}
 
-  unsigned int types = 0;
-  if(bCaptureRGB) types |= libfreenect2::Frame::Color;
-  if(bCaptureIR) types |= libfreenect2::Frame::Ir;
-  if(bCaptureDepth) types |= libfreenect2::Frame::Depth;
-  if(types == 0) {
-    throw DeviceException("Freenect2: no channel given (rgb, ir, depth)");
-  }
+	unsigned int types = 0;
+	if (bCaptureRGB)
+		types |= libfreenect2::Frame::Color;
+	if (bCaptureIR)
+		types |= libfreenect2::Frame::Ir;
+	if (bCaptureDepth)
+		types |= libfreenect2::Frame::Depth;
+	if (types == 0) {
+		throw DeviceException("Freenect2: no channel given (rgb, ir, depth)");
+	}
 
-  m_devices.reserve(N);
-  m_listeners.reserve(N);
-  m_lSerialNumbers.reserve(N);
+	m_devices.reserve(N);
+	//m_listeners.reserve(N);
+	//m_lSerialNumbers.reserve(N);
 
-  for(int i = 0; i < N; ++i) {
-    std::shared_ptr<libfreenect2::Freenect2Device> d(m_freenect2.openDevice(i));
-    if(!d) throw DeviceException("Freenect2 could not open device " +
-                                 m_freenect2.getDeviceSerialNumber(i));
+	for (int i = 0; i < N; ++i) {
+		std::shared_ptr<libfreenect2::Freenect2Device> d(
+				m_freenect2.openDevice(i));
+		if (!d)
+			throw DeviceException(
+					"Freenect2 could not open device "
+							+ m_freenect2.getDeviceSerialNumber(i));
 
-    std::shared_ptr<libfreenect2::SyncMultiFrameListener> listener =
-        std::make_shared<libfreenect2::SyncMultiFrameListener>(types);
+		std::shared_ptr<libfreenect2::SyncMultiFrameListener> listener =
+				std::make_shared<libfreenect2::SyncMultiFrameListener>(types);
 
-    if(bCaptureRGB) {
-      d->setColorFrameListener(listener.get());
-      m_dimensions.push_back(std::make_pair(m_nImgWidth, m_nImgHeight));
-    }
+		if (bCaptureRGB) {
+			d->setColorFrameListener(listener.get());
+			m_dimensions.push_back(std::make_pair(m_nImgWidth, m_nImgHeight));
+		}
 
-    if(bCaptureIR || bCaptureDepth) {
-      d->setIrAndDepthFrameListener(listener.get());
-      if(bCaptureIR) m_dimensions.push_back(
-            std::make_pair(IR_IMAGE_WIDTH, IR_IMAGE_HEIGHT));
-      if(bCaptureDepth) m_dimensions.push_back
-          ( bAlign ? std::make_pair(m_nImgWidth, m_nImgHeight) :
-                     std::make_pair(IR_IMAGE_WIDTH, IR_IMAGE_HEIGHT) );
-    }
-      
-    m_devices.emplace_back(d);
-    m_listeners.emplace_back(listener);
-    m_lSerialNumbers.push_back(ParseSerialNumber(d->getSerialNumber()));
+		if (bCaptureIR || bCaptureDepth) {
+			d->setIrAndDepthFrameListener(listener.get());
+			if (bCaptureIR)
+				m_dimensions.push_back(
+						std::make_pair(IR_IMAGE_WIDTH, IR_IMAGE_HEIGHT));
+			if (bCaptureDepth)
+				m_dimensions.push_back(
+						bAlign ?
+								std::make_pair(m_nImgWidth, m_nImgHeight) :
+								std::make_pair(IR_IMAGE_WIDTH,
+										IR_IMAGE_HEIGHT));
+		}
+		m_devices.emplace_back(d, listener,
+						ParseSerialNumber(d->getSerialNumber()));
+		if(bAlign)
+			 {
+			m_devices[m_devices.size()-1].registration.reset(DepthRegistration::New
+		                     (cv::Size(m_nImgWidth, m_nImgHeight),
+		                      cv::Size(IR_IMAGE_WIDTH, IR_IMAGE_HEIGHT),
+		                      cv::Size(IR_IMAGE_WIDTH, IR_IMAGE_HEIGHT),
+		                      0.5f, 20.0f, 0.015f, DepthRegistration::CPU));
 
-    d->start();
-  }
+		    cv::Mat cameraMatrixColor, cameraMatrixDepth;
+		    cameraMatrixColor = cv::Mat::zeros(3, 3, CV_64F);
+		    cameraMatrixDepth = cv::Mat::zeros(3, 3, CV_64F);
+		    m_devices[m_devices.size()-1].registration->ReadDefaultCameraInfo(cameraMatrixColor, cameraMatrixDepth);
 
-  if(bAlign)
-  {
-    m_depthReg.reset(DepthRegistration::New
-                     (cv::Size(m_nImgWidth, m_nImgHeight),
-                      cv::Size(IR_IMAGE_WIDTH, IR_IMAGE_HEIGHT),
-                      cv::Size(IR_IMAGE_WIDTH, IR_IMAGE_HEIGHT),
-                      0.5f, 20.0f, 0.015f, DepthRegistration::CPU));
+		    m_devices[m_devices.size()-1].registration->init(cameraMatrixColor, cameraMatrixDepth,
+		                   cv::Mat::eye(3, 3, CV_64F), cv::Mat::zeros(1, 3, CV_64F),
+		                   cv::Mat::zeros(IR_IMAGE_HEIGHT, IR_IMAGE_WIDTH, CV_32F),
+		                   cv::Mat::zeros(IR_IMAGE_HEIGHT, IR_IMAGE_WIDTH, CV_32F));
+			 }
 
-    cv::Mat cameraMatrixColor, cameraMatrixDepth;
-    cameraMatrixColor = cv::Mat::zeros(3, 3, CV_64F);
-    cameraMatrixDepth = cv::Mat::zeros(3, 3, CV_64F);
-    m_depthReg->ReadDefaultCameraInfo(cameraMatrixColor, cameraMatrixDepth);
+		d->start();
+	}
 
-    m_depthReg->init(cameraMatrixColor, cameraMatrixDepth,
-                   cv::Mat::eye(3, 3, CV_64F), cv::Mat::zeros(1, 3, CV_64F),
-                   cv::Mat::zeros(IR_IMAGE_HEIGHT, IR_IMAGE_WIDTH, CV_32F),
-                   cv::Mat::zeros(IR_IMAGE_HEIGHT, IR_IMAGE_WIDTH, CV_32F));
-  }
 }
 
-Freenect2Driver::~Freenect2Driver()
-{
-  for(auto& pdev : m_devices) {
-    pdev->stop();
-    pdev->close();
-  }
+Freenect2Driver::~Freenect2Driver() {
+	for (auto& pdev : m_devices) {
+		pdev.device->stop();
+		pdev.device->close();
+	}
 }
 
-uint64_t Freenect2Driver::ParseSerialNumber(const std::string& serial)
-{
-  try {
-    return std::strtoull(serial.c_str(), nullptr, 10);
-  } catch (...) {
-    return 0;
-  }
+uint64_t Freenect2Driver::ParseSerialNumber(const std::string& serial) {
+	try {
+		return std::strtoull(serial.c_str(), nullptr, 10);
+	} catch (...) {
+		return 0;
+	}
 }
 
-bool Freenect2Driver::Capture( hal::CameraMsg& vImages )
-{
-  vImages.Clear();
-  vImages.set_device_time(Tic());
+bool Freenect2Driver::Capture(hal::CameraMsg& vImages) {
+	vImages.Clear();
+	vImages.set_device_time(Tic());
 
-  libfreenect2::FrameMap frames;
-  libfreenect2::FrameMap::const_iterator fit;
+	libfreenect2::FrameMap frames;
+	libfreenect2::FrameMap::const_iterator fit;
 
-  for(size_t i = 0; i < m_devices.size(); ++i) {
-    m_listeners[i]->waitForNewFrame(frames);
-    const double time = Tic();
-    bool save_rgb = false;
+	for (size_t i = 0; i < m_devices.size(); ++i) {
+		m_devices[i].listener->waitForNewFrame(frames);
+		const double time = Tic();
+		bool save_rgb = false;
 
-    if((fit = frames.find(libfreenect2::Frame::Color)) != frames.end()) {
-      hal::ImageMsg* pbImg = vImages.add_image();
-      pbImg->set_timestamp(time);
-      pbImg->set_width(m_nImgWidth);
-      pbImg->set_height(m_nImgHeight);
-      pbImg->set_serial_number(m_lSerialNumbers[i]);
+		if ((fit = frames.find(libfreenect2::Frame::Color)) != frames.end()) {
+			hal::ImageMsg* pbImg = vImages.add_image();
+			pbImg->set_timestamp(time);
+			pbImg->set_width(m_nImgWidth);
+			pbImg->set_height(m_nImgHeight);
+			pbImg->set_serial_number(m_devices[i].serialNumber);
 
-      pbImg->set_type(hal::PB_UNSIGNED_BYTE);
-      if(m_bColor) pbImg->set_format(hal::PB_BGR);
-      else pbImg->set_format(hal::PB_LUMINANCE);
+			pbImg->set_type(hal::PB_UNSIGNED_BYTE);
+			if (m_bColor)
+				pbImg->set_format(hal::PB_BGR);
+			else
+				pbImg->set_format(hal::PB_LUMINANCE);
 
-      const libfreenect2::Frame* frame = fit->second;
-      cv::Mat trg(frame->height, frame->width, CV_8UC3, frame->data);
-      if(frame->height != m_nImgHeight || frame->width != m_nImgWidth)
-        cv::resize(trg, trg, cv::Size(m_nImgWidth, m_nImgHeight));
-      if(!m_bColor) cv::cvtColor(trg, trg, CV_BGR2GRAY);
-      cv::flip(trg, trg, 1);
+			const libfreenect2::Frame* frame = fit->second;
+			cv::Mat trg(frame->height, frame->width, CV_8UC3, frame->data);
+			if (frame->height != m_nImgHeight || frame->width != m_nImgWidth)
+				cv::resize(trg, trg, cv::Size(m_nImgWidth, m_nImgHeight));
+			if (!m_bColor)
+				cv::cvtColor(trg, trg, CV_BGR2GRAY);
+			cv::flip(trg, trg, 1);
 
-      pbImg->set_data(trg.ptr<unsigned char>(), trg.rows * trg.cols *
-                      trg.channels());
-      save_rgb = true;
-    }
+			pbImg->set_data(trg.ptr<unsigned char>(),
+					trg.rows * trg.cols * trg.channels());
+			save_rgb = true;
+		}
 
-    if((fit = frames.find(libfreenect2::Frame::Ir)) != frames.end()) {
-      const libfreenect2::Frame* frame = fit->second;
-      hal::ImageMsg* pbImg = vImages.add_image();
-      pbImg->set_timestamp(time);
-      pbImg->set_width(frame->width);
-      pbImg->set_height(frame->height);
-      pbImg->set_serial_number(m_lSerialNumbers[i]);
+		if ((fit = frames.find(libfreenect2::Frame::Ir)) != frames.end()) {
+			const libfreenect2::Frame* frame = fit->second;
+			hal::ImageMsg* pbImg = vImages.add_image();
+			pbImg->set_timestamp(time);
+			pbImg->set_width(frame->width);
+			pbImg->set_height(frame->height);
+			pbImg->set_serial_number(m_devices[i].serialNumber);
 
-      pbImg->set_type(hal::PB_FLOAT);
-      pbImg->set_format(hal::PB_LUMINANCE);
+			pbImg->set_type(hal::PB_FLOAT);
+			pbImg->set_format(hal::PB_LUMINANCE);
 
-      cv::Mat trg(frame->height, frame->width, CV_32F, frame->data);
-      cv::flip(trg, trg, 1);
-      pbImg->set_data(trg.ptr<float>(), trg.rows * trg.cols * sizeof(float));
-    }
+			cv::Mat trg(frame->height, frame->width, CV_32F, frame->data);
+			cv::flip(trg, trg, 1);
+			pbImg->set_data(trg.ptr<float>(),
+					trg.rows * trg.cols * sizeof(float));
+		}
 
-    if((fit = frames.find(libfreenect2::Frame::Depth)) != frames.end()) {
-      const libfreenect2::Frame* frame = fit->second;
-      cv::Mat trg = cv::Mat(frame->height, frame->width, CV_32FC1, frame->data);
+		if ((fit = frames.find(libfreenect2::Frame::Depth)) != frames.end()) {
+			const libfreenect2::Frame* frame = fit->second;
+			cv::Mat trg = cv::Mat(frame->height, frame->width, CV_32FC1,
+					frame->data);
 
-      if(save_rgb && m_bAlign)
-      {
-        if(m_nImgHeight != IR_IMAGE_HEIGHT || m_nImgWidth != IR_IMAGE_WIDTH)
-          m_depthReg->depthToRGBResolution(trg, trg);
-      }
+			if (save_rgb && m_bAlign) {
+				if (m_nImgHeight != IR_IMAGE_HEIGHT
+						|| m_nImgWidth != IR_IMAGE_WIDTH)
+					m_devices[i].registration->depthToRGBResolution(trg, trg);
+			}
 
-      // change rgb and depth image
-      hal::ImageMsg* pbImg = vImages.add_image();
-      pbImg->set_timestamp(time);
-      pbImg->set_width(trg.cols);
-      pbImg->set_height(trg.rows);
-      pbImg->set_serial_number(m_lSerialNumbers[i]);
+			// change rgb and depth image
+			hal::ImageMsg* pbImg = vImages.add_image();
+			pbImg->set_timestamp(time);
+			pbImg->set_width(trg.cols);
+			pbImg->set_height(trg.rows);
+			pbImg->set_serial_number(m_devices[i].serialNumber);
 
-      pbImg->set_type(hal::PB_FLOAT);
-      pbImg->set_format(hal::PB_LUMINANCE);
+			pbImg->set_type(hal::PB_FLOAT);
+			pbImg->set_format(hal::PB_LUMINANCE);
 
-      cv::flip(trg, trg, 1);
-      pbImg->set_data(trg.ptr<float>(), trg.rows * trg.cols * sizeof(float));
-    }
+			cv::flip(trg, trg, 1);
+			pbImg->set_data(trg.ptr<float>(),
+					trg.rows * trg.cols * sizeof(float));
+		}
 
-    m_listeners[i]->release(frames);
-  }
+		m_devices[i].listener->release(frames);
+	}
 
-  return true;
+	return true;
 }
 
-std::string Freenect2Driver::GetDeviceProperty(const std::string&)
-{
-  return std::string();
+std::string Freenect2Driver::GetDeviceProperty(const std::string&) {
+	return std::string();
 }
 
-size_t Freenect2Driver::NumChannels() const
-{
-  int channels_per_device = 0;
-  if(m_bRGB) ++channels_per_device;
-  if(m_bIR) ++channels_per_device;
-  if(m_bDepth) ++channels_per_device;
-  return m_devices.size() * channels_per_device;
+size_t Freenect2Driver::NumChannels() const {
+	int channels_per_device = 0;
+	if (m_bRGB)
+		++channels_per_device;
+	if (m_bIR)
+		++channels_per_device;
+	if (m_bDepth)
+		++channels_per_device;
+	return m_devices.size() * channels_per_device;
 }
 
-size_t Freenect2Driver::Width( size_t idx ) const
-{
-  return m_dimensions[idx].first;
+size_t Freenect2Driver::Width(size_t idx) const {
+	return m_dimensions[idx].first;
 }
 
-size_t Freenect2Driver::Height( size_t idx ) const
-{
-  return m_dimensions[idx].second;
+size_t Freenect2Driver::Height(size_t idx) const {
+	return m_dimensions[idx].second;
 }

--- a/HAL/Camera/Drivers/Freenect2/Freenect2Driver.h
+++ b/HAL/Camera/Drivers/Freenect2/Freenect2Driver.h
@@ -6,53 +6,65 @@
 
 #include <libfreenect2/libfreenect2.hpp>
 #include <libfreenect2/frame_listener_impl.h>
-#include <libfreenect2/depth_registration.h>
+/*This depth_registration is really a hack at this point. Inserting the code here that is
+  missing from latest libfreenect2 driver. The Dorian3 version contained an OpenCV-compatible
+  version of depth-to-rgb registration. The new libreenect2 driver has one that
+  is not opencv compatible, but seems to be initialized in a more proper way (using
+  rgb & ir cam params), whereas the code in Dorian3 is initialized with hard-coded values
+  for camera parameters.*/
+#include "depth_registration.h"
+
 #include "HAL/Camera/CameraDriverInterface.h"
+
+
 
 namespace hal {
 
-class Freenect2Driver : public CameraDriverInterface
-{
+struct RegisteredFreenectCam {
+	RegisteredFreenectCam(
+			std::shared_ptr<libfreenect2::Freenect2Device> dev,
+			std::shared_ptr<libfreenect2::SyncMultiFrameListener> lis,
+			uint64_t ser) :
+					device(dev),
+					listener(lis),
+					serialNumber(ser) {
+	}
+	std::shared_ptr<libfreenect2::Freenect2Device> device;
+	std::unique_ptr<DepthRegistration> registration;
+	std::shared_ptr<libfreenect2::SyncMultiFrameListener> listener;
+	uint64_t serialNumber;
+};
+
+class Freenect2Driver: public CameraDriverInterface {
 public:
-  Freenect2Driver(
-      unsigned int            nWidth,
-      unsigned int            nHeight,
-      bool                    bCaptureRGB,
-      bool                    bCaptureDepth,
-      bool                    bCaptureIR,
-      bool                    bColor,
-      bool                    bAlign
-      );
+	Freenect2Driver(unsigned int nWidth, unsigned int nHeight, bool bCaptureRGB,
+			bool bCaptureDepth, bool bCaptureIR, bool bColor, bool bAlign);
 
-  virtual ~Freenect2Driver();
+	virtual ~Freenect2Driver();
 
-  bool Capture( hal::CameraMsg& vImages );
-  std::shared_ptr<CameraDriverInterface> GetInputDevice() {
-    return std::shared_ptr<CameraDriverInterface>();
-  }
+	bool Capture(hal::CameraMsg& vImages);
+	std::shared_ptr<CameraDriverInterface> GetInputDevice() {
+		return std::shared_ptr<CameraDriverInterface>();
+	}
 
-  std::string GetDeviceProperty(const std::string& sProperty);
+	std::string GetDeviceProperty(const std::string& sProperty);
 
-  size_t NumChannels() const;
-  size_t Width( size_t idx = 0 ) const;
-  size_t Height( size_t idx = 0 ) const;
+	size_t NumChannels() const;
+	size_t Width(size_t idx = 0) const;
+	size_t Height(size_t idx = 0) const;
 
 private:
-  static uint64_t ParseSerialNumber(const std::string& serial);
+	static uint64_t ParseSerialNumber(const std::string& serial);
 
 private:
-  static const unsigned int IR_IMAGE_WIDTH;
-  static const unsigned int IR_IMAGE_HEIGHT;
-  unsigned int  m_nImgWidth;
-  unsigned int  m_nImgHeight;
-  bool          m_bRGB, m_bDepth, m_bIR, m_bColor, m_bAlign;
-  std::vector<std::pair<int,int>> m_dimensions;
-  libfreenect2::Freenect2 m_freenect2;
-  std::vector<std::shared_ptr<libfreenect2::Freenect2Device>> m_devices;
-  std::vector<std::shared_ptr
-  <libfreenect2::SyncMultiFrameListener>> m_listeners;
-  std::vector<uint64_t> m_lSerialNumbers;
-  std::unique_ptr<DepthRegistration> m_depthReg;
+	static const unsigned int IR_IMAGE_WIDTH;
+	static const unsigned int IR_IMAGE_HEIGHT;
+	unsigned int m_nImgWidth;
+	unsigned int m_nImgHeight;
+	bool m_bRGB, m_bDepth, m_bIR, m_bColor, m_bAlign;
+	std::vector<std::pair<int,int>> m_dimensions;
+	libfreenect2::Freenect2 m_freenect2;
+	std::vector<RegisteredFreenectCam> m_devices;
 };
 
 }

--- a/HAL/Camera/Drivers/Freenect2/depth_registration.cpp
+++ b/HAL/Camera/Drivers/Freenect2/depth_registration.cpp
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2014 University of Bremen, Institute for Artificial Intelligence
+ * Author: Thiemo Wiedemeyer <wiedemeyer@cs.uni-bremen.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "depth_registration.h"
+
+#ifdef DEPTH_REG_CPU
+#include "depth_registration_cpu.h"
+#endif
+
+#ifdef DEPTH_REG_OPENCL
+#include "depth_registration_opencl.h"
+#endif
+
+DepthRegistration::DepthRegistration()
+{
+  m_bInit = false;
+}
+
+DepthRegistration::~DepthRegistration()
+{
+}
+
+bool DepthRegistration::init(const cv::Mat &cameraMatrixColor, const cv::Mat &cameraMatrixDepth, const cv::Mat &rotation, const cv::Mat &translation, const cv::Mat &mapX, const cv::Mat &mapY)
+{
+  this->cameraMatrixColor = cameraMatrixColor;
+  this->cameraMatrixDepth = cameraMatrixDepth;
+  this->rotation = rotation;
+  this->translation = translation;
+  this->mapX = mapX;
+  this->mapY = mapY;
+  m_bInit = true;
+  return init();
+}
+
+
+void DepthRegistration::ReadDefaultCameraInfo( cv::Mat &cameraMatrixRGB, cv::Mat &cameraMatrixDepth)
+{
+  cameraMatrixDepth.at<double>(0,0) = 3.6638346288148574e+02;
+  cameraMatrixDepth.at<double>(0,1) = 0;
+  cameraMatrixDepth.at<double>(0,2) = 2.5564531890330468e+02;
+  cameraMatrixDepth.at<double>(0,3) = 0;
+  cameraMatrixDepth.at<double>(0,4) = 3.6714380707081017e+02;
+  cameraMatrixDepth.at<double>(0,5) = 2.0398020160452000e+02;
+  cameraMatrixDepth.at<double>(0,6) = 0;
+  cameraMatrixDepth.at<double>(0,7) = 0;
+  cameraMatrixDepth.at<double>(0,8) = 1;
+
+
+  cameraMatrixRGB.at<double>(0,0) = 1.0607072507083330e+03;
+  cameraMatrixRGB.at<double>(0,1) = 0;
+  cameraMatrixRGB.at<double>(0,2) = 9.5635447181548398e+02;
+  cameraMatrixRGB.at<double>(0,3) = 0;
+  cameraMatrixRGB.at<double>(0,4) = 1.0586083263054650e+03;
+  cameraMatrixRGB.at<double>(0,5) = 5.1897844298824486e+02;
+  cameraMatrixRGB.at<double>(0,6) = 0;
+  cameraMatrixRGB.at<double>(0,7) = 0;
+  cameraMatrixRGB.at<double>(0,8) = 1;
+}
+
+
+DepthRegistration *DepthRegistration::New(const cv::Size &color, const cv::Size &depth, const cv::Size &raw, const float zNear, const float zFar, const float zDist, Method method)
+{
+  if(method == DEFAULT)
+  {
+#ifdef DEPTH_REG_OPENCL
+    method = OPENCL;
+#elif defined DEPTH_REG_CPU
+    method = CPU;
+#endif
+  }
+
+  switch(method)
+  {
+  case DEFAULT:
+    std::cerr << "No default registration method available!" << std::endl;
+    break;
+  case CPU:
+#ifdef DEPTH_REG_CPU
+    std::cout << "Using CPU registration method!" << std::endl;
+    return new DepthRegistrationCPU(color, depth, raw, zNear, zFar);
+#else
+    std::cerr << "CPU registration method not available!" << std::endl;
+    break;
+#endif
+  case OPENCL:
+#ifdef DEPTH_REG_OPENCL
+    std::cout << "Using OpenCL registration method!" << std::endl;
+    return new DepthRegistrationOpenCL(color, depth, raw, zNear, zFar, zDist);
+#else
+    std::cerr << "OpenCL registration method not available!" << std::endl;
+    break;
+#endif
+  }
+  return NULL;
+}

--- a/HAL/Camera/Drivers/Freenect2/depth_registration.h
+++ b/HAL/Camera/Drivers/Freenect2/depth_registration.h
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2014 University of Bremen, Institute for Artificial Intelligence
+ * Author: Thiemo Wiedemeyer <wiedemeyer@cs.uni-bremen.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#ifndef __DEPTH_REGISTRATION_H__
+#define __DEPTH_REGISTRATION_H__
+
+#define DEPTH_REG_CPU
+
+#include <vector>
+
+#include <opencv2/opencv.hpp>
+
+class DepthRegistration
+{
+public:
+  enum Method
+  {
+    DEFAULT = 0,
+    CPU,
+    OPENCL
+  };
+
+protected:
+  cv::Mat cameraMatrixColor, cameraMatrixDepth, rotation, translation, mapX, mapY;
+
+  DepthRegistration();
+
+  virtual bool init() = 0;
+
+public:
+  virtual ~DepthRegistration();
+
+  bool init(const cv::Mat &cameraMatrixColor, const cv::Mat &cameraMatrixDepth, const cv::Mat &rotation, const cv::Mat &translation, const cv::Mat &mapX, const cv::Mat &mapY);
+
+  void ReadDefaultCameraInfo( cv::Mat &cameraMatrixRGB, cv::Mat &cameraMatrixDepth);
+
+  virtual void remapDepth(const cv::Mat &in, cv::Mat &out) const = 0;
+
+  virtual void registerDepth(const cv::Mat &depth, cv::Mat &registered) = 0;
+
+  virtual void depthToRGBResolution(const cv::Mat &registered, cv::Mat &upscaled) = 0;
+
+  static DepthRegistration *New(const cv::Size &color, const cv::Size &depth, const cv::Size &raw, const float zNear = 0.5f, const float zFar = 12.0f, const float zDist = 0.015f, Method method = DEFAULT);
+
+  bool m_bInit;
+};
+
+#endif //__DEPTH_REGISTRATION_H__

--- a/HAL/Camera/Drivers/Freenect2/depth_registration_cpu.cpp
+++ b/HAL/Camera/Drivers/Freenect2/depth_registration_cpu.cpp
@@ -1,0 +1,206 @@
+/**
+ * Copyright 2014 University of Bremen, Institute for Artificial Intelligence
+ * Author: Thiemo Wiedemeyer <wiedemeyer@cs.uni-bremen.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <eigen3/Eigen/Geometry>
+#include "depth_registration_cpu.h"
+#include <opencv2/core/core_c.h>
+
+DepthRegistrationCPU::DepthRegistrationCPU(const cv::Size &color, const cv::Size &depth, const cv::Size &raw, const float zNear, const float zFar)
+  : DepthRegistration(), sizeDepth(depth), sizeColor(color), zNear(zNear), zFar(zFar)
+{
+}
+
+DepthRegistrationCPU::~DepthRegistrationCPU()
+{
+}
+
+bool DepthRegistrationCPU::init()
+{
+  createLookup();
+
+  cv::initUndistortRectifyMap(cameraMatrixDepth, cv::Mat(), cv::Mat(), cameraMatrixColor, sizeColor, CV_16SC2, map1, map2);
+  return true;
+}
+
+inline uint16_t DepthRegistrationCPU::interpolate(const cv::Mat &in, const float &x, const float &y) const
+{
+  const int xL = (int)floor(x);
+  const int xH = (int)ceil(x);
+  const int yL = (int)floor(y);
+  const int yH = (int)ceil(y);
+
+  if(xL < 0 || yL < 0 || xH >= in.cols || yH >= in.rows)
+  {
+    return 0;
+  }
+
+  const uint16_t pLT = in.at<uint16_t>(yL, xL);
+  const uint16_t pRT = in.at<uint16_t>(yL, xH);
+  const uint16_t pLB = in.at<uint16_t>(yH, xL);
+  const uint16_t pRB = in.at<uint16_t>(yH, xH);
+  int vLT = pLT > 0;
+  int vRT = pRT > 0;
+  int vLB = pLB > 0;
+  int vRB = pRB > 0;
+  int count = vLT + vRT + vLB + vRB;
+
+  if(count < 3)
+  {
+    return 0;
+  }
+
+  const uint16_t avg = (pLT + pRT + pLB + pRB) / count;
+  const uint16_t thres = 0.01 * avg;
+  vLT = abs(pLT - avg) < thres;
+  vRT = abs(pRT - avg) < thres;
+  vLB = abs(pLB - avg) < thres;
+  vRB = abs(pRB - avg) < thres;
+  count = vLT + vRT + vLB + vRB;
+
+  if(count < 3)
+  {
+    return 0;
+  }
+
+  double distXL = x - xL;
+  double distXH = 1.0 - distXL;
+  double distYL = y - yL;
+  double distYH = 1.0 - distYL;
+  distXL *= distXL;
+  distXH *= distXH;
+  distYL *= distYL;
+  distYH *= distYL;
+  const double tmp = sqrt(2.0);
+  const double fLT = vLT ? tmp - sqrt(distXL + distYL) : 0;
+  const double fRT = vRT ? tmp - sqrt(distXH + distYL) : 0;
+  const double fLB = vLB ? tmp - sqrt(distXL + distYH) : 0;
+  const double fRB = vRB ? tmp - sqrt(distXH + distYH) : 0;
+  const double sum = fLT + fRT + fLB + fRB;
+
+  return ((pLT * fLT +  pRT * fRT + pLB * fLB + pRB * fRB) / sum) + 0.5;
+}
+
+void DepthRegistrationCPU::remapDepth(const cv::Mat &in, cv::Mat &out) const
+{
+  out.create(mapX.rows, mapX.cols, CV_16U);
+  #pragma omp parallel for
+  for(size_t r = 0; r < (size_t)out.rows; ++r)
+  {
+    uint16_t *itO = out.ptr<uint16_t>(r);
+    const float *itX = mapX.ptr<float>(r);
+    const float *itY = mapY.ptr<float>(r);
+    for(size_t c = 0; c < (size_t)out.cols; ++c, ++itO, ++itX, ++itY)
+    {
+      *itO = interpolate(in, *itX, *itY);
+    }
+  }
+}
+
+void DepthRegistrationCPU::registerDepth(const cv::Mat &depth, cv::Mat &registered)
+{
+  registered = cv::Mat::zeros(sizeDepth, CV_16U);
+
+  Eigen::Matrix4d proj;
+  proj(0, 0) = rotation.at<double>(0, 0);
+  proj(0, 1) = rotation.at<double>(0, 1);
+  proj(0, 2) = rotation.at<double>(0, 2);
+  proj(0, 3) = translation.at<double>(0, 0);
+  proj(1, 0) = rotation.at<double>(1, 0);
+  proj(1, 1) = rotation.at<double>(1, 1);
+  proj(1, 2) = rotation.at<double>(1, 2);
+  proj(1, 3) = translation.at<double>(1, 0);
+  proj(2, 0) = rotation.at<double>(2, 0);
+  proj(2, 1) = rotation.at<double>(2, 1);
+  proj(2, 2) = rotation.at<double>(2, 2);
+  proj(2, 3) = translation.at<double>(2, 0);
+  proj(3, 0) = 0;
+  proj(3, 1) = 0;
+  proj(3, 2) = 0;
+  proj(3, 3) = 1;
+
+  const double fx = cameraMatrixDepth.at<double>(0, 0);
+  const double fy = cameraMatrixDepth.at<double>(1, 1);
+  const double cx = cameraMatrixDepth.at<double>(0, 2) + 0.5;
+  const double cy = cameraMatrixDepth.at<double>(1, 2) + 0.5;
+
+  #pragma omp parallel for
+  for(size_t r = 0; r < (size_t)sizeDepth.height; ++r)
+  {
+    const uint16_t *itD = depth.ptr<uint16_t>(r);
+    const double y = lookupY.at<double>(0, r);
+    const double *itX = lookupX.ptr<double>();
+
+    for(size_t c = 0; c < (size_t)sizeDepth.width; ++c, ++itD, ++itX)
+    {
+      const double depthValue = *itD / 1000.0;
+
+      if(depthValue < zNear || depthValue > zFar)
+      {
+        continue;
+      }
+
+      Eigen::Vector4d pointD(*itX * depthValue, y * depthValue, depthValue, 1);
+      Eigen::Vector4d pointP = proj * pointD;
+
+      const double z = pointP[2];
+
+      const double invZ = 1 / z;
+      const int xP = (fx * pointP[0]) * invZ + cx;
+      const int yP = (fy * pointP[1]) * invZ + cy;
+
+      if(xP >= 0 && xP < sizeDepth.width && yP >= 0 && yP < sizeDepth.height)
+      {
+        const uint16_t z16 = z * 1000;
+        uint16_t &zReg = registered.at<uint16_t>(yP, xP);
+        if(zReg == 0 || z16 < zReg)
+        {
+          zReg = z16;
+        }
+      }
+    }
+  }
+
+}
+
+void DepthRegistrationCPU::depthToRGBResolution(const cv::Mat &registered, cv::Mat &upscaled)
+{
+  cv::remap(registered, upscaled, map1, map2, cv::INTER_NEAREST);
+  cv::medianBlur(upscaled, upscaled, 5);
+}
+
+void DepthRegistrationCPU::createLookup()
+{
+  const double fx = 1.0 / cameraMatrixDepth.at<double>(0, 0);
+  const double fy = 1.0 / cameraMatrixDepth.at<double>(1, 1);
+  const double cx = cameraMatrixDepth.at<double>(0, 2);
+  const double cy = cameraMatrixDepth.at<double>(1, 2);
+  double *it;
+
+  lookupY = cv::Mat(1, sizeDepth.height, CV_64F);
+  it = lookupY.ptr<double>();
+  for(size_t r = 0; r < (size_t)sizeDepth.height; ++r, ++it)
+  {
+    *it = (r - cy) * fy;
+  }
+
+  lookupX = cv::Mat(1, sizeDepth.width, CV_64F);
+  it = lookupX.ptr<double>();
+  for(size_t c = 0; c < (size_t)sizeDepth.width; ++c, ++it)
+  {
+    *it = (c - cx) * fx;
+  }
+}

--- a/HAL/Camera/Drivers/Freenect2/depth_registration_cpu.h
+++ b/HAL/Camera/Drivers/Freenect2/depth_registration_cpu.h
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2014 University of Bremen, Institute for Artificial Intelligence
+ * Author: Thiemo Wiedemeyer <wiedemeyer@cs.uni-bremen.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#ifndef __DEPTH_REGISTRATION_CPU_H__
+#define __DEPTH_REGISTRATION_CPU_H__
+
+#include "depth_registration.h"
+
+class DepthRegistrationCPU : public DepthRegistration
+{
+private:
+  const cv::Size sizeDepth, sizeColor;
+
+  const float zNear;
+  const float zFar;
+
+  cv::Mat lookupX, lookupY;
+  cv::Mat map1, map2;
+
+public:
+  DepthRegistrationCPU(const cv::Size &color, const cv::Size &depth, const cv::Size &raw, const float zNear = 0.5f, const float zFar = 12.0f);
+
+  ~DepthRegistrationCPU();
+
+  bool init();
+
+  void remapDepth(const cv::Mat &in, cv::Mat &out) const;
+
+  void registerDepth(const cv::Mat &depth, cv::Mat &registered);
+
+  void depthToRGBResolution(const cv::Mat &registered, cv::Mat &upscaled);
+
+private:
+  void createLookup();
+
+  uint16_t interpolate(const cv::Mat &in, const float &x, const float &y) const;
+};
+
+#endif //__DEPTH_REGISTRATION_CPU_H__

--- a/HAL/Camera/Drivers/Freenect2/depth_registration_opencl.cpp
+++ b/HAL/Camera/Drivers/Freenect2/depth_registration_opencl.cpp
@@ -1,0 +1,316 @@
+/**
+ * Copyright 2014 University of Bremen, Institute for Artificial Intelligence
+ * Author: Thiemo Wiedemeyer <wiedemeyer@cs.uni-bremen.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fstream>
+
+#define __CL_ENABLE_EXCEPTIONS
+#ifdef __APPLE__
+  #include <OpenCL/cl.hpp>
+#else
+  #include <CL/cl.hpp>
+#endif
+
+#ifndef REG_OPENCL_FILE
+#define REG_OPENCL_FILE ""
+#endif
+
+#include "depth_registration_opencl.h"
+
+struct DepthRegistrationOpenCL::OCLData
+{
+  cl::Context context;
+  std::vector<cl::Platform> platforms;
+  std::vector<cl::Device> devices;
+
+  cl::Program program;
+  cl::CommandQueue queue;
+
+  cl::Kernel kernelSetZero;
+  cl::Kernel kernelProject;
+  cl::Kernel kernelRender;
+  cl::Kernel kernelRemap;
+
+  size_t sizeDepth;
+  size_t sizeIndex;
+  size_t sizeImgZ;
+  size_t sizeDists;
+  size_t sizeSelDist;
+  size_t sizeRendered;
+  size_t sizeRaw;
+  size_t sizeMap;
+
+  cl::Buffer bufferDepth;
+  cl::Buffer bufferIndex;
+  cl::Buffer bufferImgZ;
+  cl::Buffer bufferDists;
+  cl::Buffer bufferSelDist;
+  cl::Buffer bufferRendered;
+  cl::Buffer bufferRemapIn;
+  cl::Buffer bufferRemapOut;
+  cl::Buffer bufferMapX;
+  cl::Buffer bufferMapY;
+};
+
+DepthRegistrationOpenCL::DepthRegistrationOpenCL(const cv::Size &color, const cv::Size &depth, const cv::Size &raw, const float zNear, const float zFar, const float zDist)
+  : DepthRegistration(), sizeColor(color), sizeDepth(depth), sizeRaw(raw), zNear(zNear * 1000), zFar(zFar * 1000), zDist(zDist)
+{
+  data = new OCLData;
+}
+
+DepthRegistrationOpenCL::~DepthRegistrationOpenCL()
+{
+  delete data;
+}
+
+bool DepthRegistrationOpenCL::init()
+{
+  std::string sourceCode;
+  if(!readProgram(sourceCode))
+  {
+    return false;
+  }
+
+  cl_int err = CL_SUCCESS;
+  try
+  {
+    cl::Platform::get(&data->platforms);
+    if(data->platforms.size() == 0)
+    {
+      std::cerr << "Platform size 0" << std::endl;
+      return false;
+    }
+
+    cl_context_properties properties[] = { CL_CONTEXT_PLATFORM, (cl_context_properties)(data->platforms[0])(), 0};
+    data->context = cl::Context(CL_DEVICE_TYPE_GPU, properties);
+
+    data->devices = data->context.getInfo<CL_CONTEXT_DEVICES>();
+
+    std::string options;
+    generateOptions(options);
+
+    cl::Program::Sources source(1, std::make_pair(sourceCode.c_str(), sourceCode.length()));
+    data->program = cl::Program(data->context, source);
+    data->program.build(data->devices, options.c_str());
+
+    data->queue = cl::CommandQueue(data->context, data->devices[0], 0, &err);
+
+    data->sizeDepth = sizeDepth.height * sizeDepth.width * sizeof(uint16_t);
+    data->sizeIndex = sizeDepth.height * sizeDepth.width * sizeof(cl_int4);
+    data->sizeImgZ = sizeDepth.height * sizeDepth.width * sizeof(uint16_t);
+    data->sizeDists = sizeDepth.height * sizeDepth.width * sizeof(cl_float4);
+    data->sizeSelDist = sizeDepth.height * sizeDepth.width * sizeof(float);
+    data->sizeRendered = sizeDepth.height * sizeDepth.width * sizeof(uint16_t);
+    data->sizeRaw = sizeRaw.height * sizeRaw.width * sizeof(uint16_t);
+    data->sizeMap = sizeDepth.height * sizeDepth.width * sizeof(float);
+
+    data->bufferDepth = cl::Buffer(data->context, CL_READ_ONLY_CACHE, data->sizeDepth, NULL, &err);
+    data->bufferIndex = cl::Buffer(data->context, CL_READ_WRITE_CACHE, data->sizeIndex, NULL, &err);
+    data->bufferImgZ = cl::Buffer(data->context, CL_READ_WRITE_CACHE, data->sizeImgZ, NULL, &err);
+    data->bufferDists = cl::Buffer(data->context, CL_READ_WRITE_CACHE, data->sizeDists, NULL, &err);
+    data->bufferSelDist = cl::Buffer(data->context, CL_READ_WRITE_CACHE, data->sizeSelDist, NULL, &err);
+    data->bufferRendered = cl::Buffer(data->context, CL_READ_WRITE_CACHE, data->sizeRendered, NULL, &err);
+    data->bufferRemapIn = cl::Buffer(data->context, CL_READ_ONLY_CACHE, data->sizeRaw, NULL, &err);
+    data->bufferRemapOut = cl::Buffer(data->context, CL_READ_WRITE_CACHE, data->sizeDepth, NULL, &err);
+    data->bufferMapX = cl::Buffer(data->context, CL_READ_ONLY_CACHE, data->sizeMap, NULL, &err);
+    data->bufferMapY = cl::Buffer(data->context, CL_READ_ONLY_CACHE, data->sizeMap, NULL, &err);
+
+    data->kernelSetZero = cl::Kernel(data->program, "setZero", &err);
+    data->kernelSetZero.setArg(0, data->bufferRendered);
+    data->kernelSetZero.setArg(1, data->bufferSelDist);
+
+    data->kernelProject = cl::Kernel(data->program, "project", &err);
+    data->kernelProject.setArg(0, data->bufferDepth);
+    data->kernelProject.setArg(1, data->bufferIndex);
+    data->kernelProject.setArg(2, data->bufferImgZ);
+    data->kernelProject.setArg(3, data->bufferDists);
+    data->kernelProject.setArg(4, data->bufferSelDist);
+    data->kernelProject.setArg(5, data->bufferRendered);
+
+    data->kernelRender = cl::Kernel(data->program, "render", &err);
+    data->kernelRender.setArg(0, data->bufferIndex);
+    data->kernelRender.setArg(1, data->bufferImgZ);
+    data->kernelRender.setArg(2, data->bufferDists);
+    data->kernelRender.setArg(3, data->bufferSelDist);
+    data->kernelRender.setArg(4, data->bufferRendered);
+
+    data->kernelRemap = cl::Kernel(data->program, "remapDepth", &err);
+    data->kernelRemap.setArg(0, data->bufferRemapIn);
+    data->kernelRemap.setArg(1, data->bufferRemapOut);
+    data->kernelRemap.setArg(2, data->bufferMapX);
+    data->kernelRemap.setArg(3, data->bufferMapY);
+
+    data->queue.enqueueWriteBuffer(data->bufferMapX, CL_TRUE, 0, data->sizeMap, mapX.data);
+    data->queue.enqueueWriteBuffer(data->bufferMapY, CL_TRUE, 0, data->sizeMap, mapY.data);
+  }
+  catch(cl::Error err)
+  {
+    std::cerr << "ERROR: " << err.what() << "(" << err.err() << ")" << std::endl;
+
+    if(err.err() == CL_BUILD_PROGRAM_FAILURE)
+    {
+      std::cout << "Build Status: " << data->program.getBuildInfo<CL_PROGRAM_BUILD_STATUS>(data->devices[0]) << std::endl;
+      std::cout << "Build Options:\t" << data->program.getBuildInfo<CL_PROGRAM_BUILD_OPTIONS>(data->devices[0]) << std::endl;
+      std::cout << "Build Log:\t " << data->program.getBuildInfo<CL_PROGRAM_BUILD_LOG>(data->devices[0]) << std::endl;
+    }
+
+    return false;
+  }
+
+  cv::initUndistortRectifyMap(cameraMatrixDepth, cv::Mat(), cv::Mat(), cameraMatrixColor, sizeColor, CV_16SC2, map1, map2);
+  return true;
+}
+
+void DepthRegistrationOpenCL::remapDepth(const cv::Mat &in, cv::Mat &out) const
+{
+  if(out.empty() || out.rows != sizeDepth.height || out.cols != sizeDepth.width || out.type() != CV_16U)
+  {
+    out = cv::Mat(sizeDepth, CV_16U);
+  }
+
+  try
+  {
+    cl::Event eventKernel;
+    cl::NDRange range(sizeDepth.height * sizeDepth.width);
+
+    data->queue.enqueueWriteBuffer(data->bufferRemapIn, CL_TRUE, 0, data->sizeRaw, in.data);
+
+    data->queue.enqueueNDRangeKernel(data->kernelRemap, cl::NullRange, range, cl::NullRange, NULL, &eventKernel);
+    eventKernel.wait();
+
+    data->queue.enqueueReadBuffer(data->bufferRemapOut, CL_TRUE, 0, data->sizeDepth, out.data);
+  }
+  catch(cl::Error err)
+  {
+    std::cerr << "ERROR: " << err.what() << "(" << err.err() << ")" << std::endl;
+    return;
+  }
+}
+
+void DepthRegistrationOpenCL::registerDepth(const cv::Mat &depth, cv::Mat &registered)
+{
+  if(registered.empty() || registered.rows != sizeDepth.height || registered.cols != sizeDepth.width || registered.type() != CV_16U)
+  {
+    registered = cv::Mat(sizeDepth, CV_16U);
+  }
+
+  try
+  {
+    cl::Event eventBuffer, eventKernel;
+    cl::NDRange range(sizeDepth.height * sizeDepth.width);
+
+    data->queue.enqueueNDRangeKernel(data->kernelSetZero, cl::NullRange, range, cl::NullRange, NULL, &eventKernel);
+    data->queue.enqueueWriteBuffer(data->bufferDepth, CL_FALSE, 0, data->sizeDepth, depth.data, NULL, &eventBuffer);
+    eventBuffer.wait();
+    eventKernel.wait();
+
+    data->queue.enqueueNDRangeKernel(data->kernelProject, cl::NullRange, range, cl::NullRange, NULL, &eventKernel);
+    eventKernel.wait();
+
+    data->queue.enqueueNDRangeKernel(data->kernelRender, cl::NullRange, range, cl::NullRange, NULL, &eventKernel);
+    eventKernel.wait();
+    //data->queue.enqueueNDRangeKernel(data->kernelRender, cl::NullRange, range, cl::NullRange, NULL, &eventKernel);
+    //eventKernel.wait();
+    //data->queue.enqueueNDRangeKernel(data->kernelRender, cl::NullRange, range, cl::NullRange, NULL, &eventKernel);
+    //eventKernel.wait();
+
+    data->queue.enqueueReadBuffer(data->bufferRendered, CL_FALSE, 0, data->sizeRendered, registered.data, NULL, &eventBuffer);
+    eventBuffer.wait();
+  }
+  catch(cl::Error err)
+  {
+    std::cerr << "ERROR: " << err.what() << "(" << err.err() << ")" << std::endl;
+    return;
+  }
+}
+
+void DepthRegistrationOpenCL::depthToRGBResolution(const cv::Mat &registered, cv::Mat &upscaled)
+{
+  cv::remap(registered, upscaled, map1, map2, cv::INTER_NEAREST);
+  //cv::medianBlur(upscaled, upscaled, 5);
+}
+
+void DepthRegistrationOpenCL::generateOptions(std::string &options) const
+{
+  std::ostringstream oss;
+  oss.precision(16);
+  oss << std::scientific;
+
+  // Rotation
+  oss << " -D r00=" << rotation.at<double>(0, 0) << "f";
+  oss << " -D r01=" << rotation.at<double>(0, 1) << "f";
+  oss << " -D r02=" << rotation.at<double>(0, 2) << "f";
+  oss << " -D r10=" << rotation.at<double>(1, 0) << "f";
+  oss << " -D r11=" << rotation.at<double>(1, 1) << "f";
+  oss << " -D r12=" << rotation.at<double>(1, 2) << "f";
+  oss << " -D r20=" << rotation.at<double>(2, 0) << "f";
+  oss << " -D r21=" << rotation.at<double>(2, 1) << "f";
+  oss << " -D r22=" << rotation.at<double>(2, 2) << "f";
+
+  // Translation
+  oss << " -D tx=" << translation.at<double>(0, 0) << "f";
+  oss << " -D ty=" << translation.at<double>(1, 0) << "f";
+  oss << " -D tz=" << translation.at<double>(2, 0) << "f";
+
+  // Camera parameter upscaled depth
+  oss << " -D fxD=" << cameraMatrixDepth.at<double>(0, 0) << "f";
+  oss << " -D fyD=" << cameraMatrixDepth.at<double>(1, 1) << "f";
+  oss << " -D cxD=" << cameraMatrixDepth.at<double>(0, 2) << "f";
+  oss << " -D cyD=" << cameraMatrixDepth.at<double>(1, 2) << "f";
+  oss << " -D fxDInv=" << (1.0 / cameraMatrixDepth.at<double>(0, 0)) << "f";
+  oss << " -D fyDInv=" << (1.0 / cameraMatrixDepth.at<double>(1, 1)) << "f";
+
+  // Camera parameter color
+  oss << " -D fxC=" << cameraMatrixColor.at<double>(0, 0) << "f";
+  oss << " -D fyC=" << cameraMatrixColor.at<double>(1, 1) << "f";
+  oss << " -D cxC=" << cameraMatrixColor.at<double>(0, 2) << "f";
+  oss << " -D cyC=" << cameraMatrixColor.at<double>(1, 2) << "f";
+
+  // Clipping distances
+  oss << " -D zNear=" << zNear;
+  oss << " -D zFar=" << zFar;
+  oss << " -D zDist=" << zDist << "f";
+
+  // Size color image
+  oss << " -D heightC=" << sizeColor.height;
+  oss << " -D widthC=" << sizeColor.width;
+
+  // Size depth image
+  oss << " -D heightD=" << sizeDepth.height;
+  oss << " -D widthD=" << sizeDepth.width;
+
+  // Size raw depth image
+  oss << " -D heightR=" << sizeRaw.height;
+  oss << " -D widthR=" << sizeRaw.width;
+
+  options = oss.str();
+}
+
+bool DepthRegistrationOpenCL::readProgram(std::string &source) const
+{
+  std::ifstream file(REG_OPENCL_FILE);
+
+  if(!file.is_open())
+  {
+    return false;
+  }
+
+  source = std::string((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+  file.close();
+
+  //std::cout << source << std::endl;
+  return true;
+}

--- a/HAL/Camera/Drivers/Freenect2/depth_registration_opencl.h
+++ b/HAL/Camera/Drivers/Freenect2/depth_registration_opencl.h
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2014 University of Bremen, Institute for Artificial Intelligence
+ * Author: Thiemo Wiedemeyer <wiedemeyer@cs.uni-bremen.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#ifndef __DEPTH_REGISTRATION_OPENCL_H__
+#define __DEPTH_REGISTRATION_OPENCL_H__
+
+#include <libfreenect2/depth_registration.h>
+
+class DepthRegistrationOpenCL : public DepthRegistration
+{
+private:
+  struct OCLData;
+
+  const cv::Size sizeColor, sizeDepth, sizeRaw;
+
+  const uint16_t zNear;
+  const uint16_t zFar;
+  const float zDist;
+
+  OCLData *data;
+  cv::Mat map1, map2;
+
+public:
+  DepthRegistrationOpenCL(const cv::Size &color, const cv::Size &depth, const cv::Size &raw, const float zNear = 0.5f, const float zFar = 12.0f, const float zDist = 0.015f);
+
+  ~DepthRegistrationOpenCL();
+
+  bool init();
+
+  void remapDepth(const cv::Mat &in, cv::Mat &out) const;
+
+  void registerDepth(const cv::Mat &depth, cv::Mat &registered);
+
+  void depthToRGBResolution(const cv::Mat &registered, cv::Mat &upscaled);
+
+private:
+  void generateOptions(std::string &options) const;
+
+  bool readProgram(std::string &source) const;
+};
+
+#endif //__DEPTH_REGISTRATION_OPENCL_H__


### PR DESCRIPTION
This is directly related to #82.
I had no clue this was apparently being done already by Dorian himself in #63. Anyway, this is a temporary fix for that that uses exactly the same code as dorian3d's libfreenect2 fork for depth registration and seems to have no merge conflicts. We can use this until #63 is merged.