### PR TITLE
Fixes/convert underrun

### DIFF
--- a/HAL/Camera/Drivers/Convert/ConvertDriver.cpp
+++ b/HAL/Camera/Drivers/Convert/ConvertDriver.cpp
@@ -62,8 +62,11 @@ ConvertDriver::ConvertDriver(
 bool ConvertDriver::Capture( hal::CameraMsg& vImages )
 {
   m_Message.Clear();
-  m_Input->Capture( m_Message );
+  bool srcGood = m_Input->Capture( m_Message );
 
+  if (!srcGood)
+    return false;
+  
   // Guess source color coding.
   if( m_nCvType.empty() ) {
     for(int i = 0; i < m_Message.image_size(); ++i) {

--- a/HAL/Camera/Drivers/ROS/ROSDriver.cpp
+++ b/HAL/Camera/Drivers/ROS/ROSDriver.cpp
@@ -213,6 +213,8 @@ namespace hal {
       return hal::PB_UNSIGNED_BYTE;
     if (format == sensor_msgs::image_encodings::MONO16)
       return hal::PB_UNSIGNED_SHORT;
+    if (format == sensor_msgs::image_encodings::TYPE_8UC1)
+      return hal::PB_UNSIGNED_BYTE;
     if (format == sensor_msgs::image_encodings::TYPE_16UC1)
       return hal::PB_UNSIGNED_SHORT;
     if (format == sensor_msgs::image_encodings::TYPE_32FC1)
@@ -230,6 +232,9 @@ namespace hal {
     if (format == sensor_msgs::image_encodings::MONO16)
       return hal::PB_LUMINANCE;
     
+    if (format == sensor_msgs::image_encodings::TYPE_8UC1)
+      return hal::PB_LUMINANCE;
+
     if (format == sensor_msgs::image_encodings::TYPE_16UC1)
       return hal::PB_LUMINANCE;
     


### PR DESCRIPTION
Adds support for OpenCV types in the ROS driver, and corrects a segfault in convert when an underlying capture driver has no more images to give (such as a FileReader)
