### PR TITLE
Fixed JoinCameraDriver thread handling on destruction bug

### DIFF
--- a/HAL/Camera/CameraDevice.h
+++ b/HAL/Camera/CameraDevice.h
@@ -25,7 +25,7 @@ public:
     Camera(const std::string& uri)
         : m_uri(uri)
     {
-        m_cam = DeviceRegistry<CameraDriverInterface>::Instance().Create(m_uri, "Cam");
+        m_cam = DeviceRegistry<CameraDriverInterface>::Instance().Create(m_uri);
     }
 
     ///////////////////////////////////////////////////////////////

--- a/HAL/Camera/Drivers/Join/JoinCameraDriver.h
+++ b/HAL/Camera/Drivers/Join/JoinCameraDriver.h
@@ -39,9 +39,13 @@ private:
   class WorkTeam
   {
   public:
-    WorkTeam(){}
+    WorkTeam():m_bStopRequested(false){}
     void addWorker(std::shared_ptr<CameraDriverInterface>& cam);
     std::vector<hal::CameraMsg>& process();
+    /**
+     * Stop the work team permanently
+     */
+    void stopTeam();
 
   private:
     void waitForWork(size_t workerId);
@@ -49,12 +53,14 @@ private:
     void Worker(std::shared_ptr<CameraDriverInterface>& cam,
                 size_t workerId);
 
+
   private:
     std::vector<std::thread> m_Workers;
     std::vector<bool> m_bWorkerDone;
     std::vector<hal::CameraMsg> m_ImageData;
     std::mutex m_Mutex;
     std::condition_variable m_WorkerCond, m_MasterCond;
+    bool m_bStopRequested;
   };
 
   WorkTeam                  m_WorkTeam;

--- a/HAL/Camera/Drivers/OpenCV/README
+++ b/HAL/Camera/Drivers/OpenCV/README
@@ -1,0 +1,13 @@
+The OpenCV driver allows to stream video from OpenCV VideoCapture, which can be either a camera or
+a file.
+
+Usage:
+	opencv:[id=<video_device_id>]
+			- OR -
+	opencv://<path_to_video_file>
+	
+Examples:
+	opencv:[id=2]
+	opencv:///media/lameusername/data/cap/video1_h264.mp4
+
+Note that if the <path_to_video_file> is used together with the id property, the id will be ignored.


### PR DESCRIPTION
1) Fixed JoinCameraDrier thread handling, now the threads are joined before the object is destroyed.
2) Added a README to OpenCV Driver.
3) Fixed minor bug preventing build in CameraDevice.h