### PR TITLE
JoinCameraDriver capture return fixed

### DIFF
--- a/HAL/Camera/Drivers/Join/JoinCameraDriver.h
+++ b/HAL/Camera/Drivers/Join/JoinCameraDriver.h
@@ -40,6 +40,7 @@ private:
   {
   public:
     WorkTeam():m_bStopRequested(false){}
+    std::vector<bool> m_bWorkerCaptureNotOver;
     void addWorker(std::shared_ptr<CameraDriverInterface>& cam);
     std::vector<hal::CameraMsg>& process();
     /**


### PR DESCRIPTION
With this patch, when capture for individual CameraDrivers within JoinCameraDriver returns false, the frame is not refreshed for those channels. (Previously, "fake" image messages pointed to unallocated memory, which was prone to cause crashes). When all internal drivers' Capture returns false, the Join driver's Capture also returns false, allowing for possible capture stop condition checks.