### PR TITLE
Fixed HAL/OpenCV3 interoperability

### DIFF
--- a/HAL/CMakeLists.txt
+++ b/HAL/CMakeLists.txt
@@ -31,14 +31,7 @@ endif()
 find_package( Sophus REQUIRED )
 find_package( GLog REQUIRED )
 find_package( TinyXML2 QUIET )
-find_package( OpenCV QUIET COMPONENTS core)
-if( OpenCV_FOUND )
-    add_definitions( -DHAVE_OPENCV )
-    list(APPEND LINK_LIBS ${OpenCV_LIBS})
-    list(APPEND USER_INC ${OpenCV_INCLUDE_DIRS})
-else()
-    message(STATUS "OpenCV not found")
-endif()
+
 if(TinyXML2_FOUND)
   add_definitions(-DHAVE_TINYXML2)
   list(APPEND LINK_LIBS  ${TinyXML2_LIBRARIES})
@@ -53,12 +46,6 @@ list( APPEND USER_INC   ${GLog_INCLUDE_DIRS} )
 include_directories( ${LIB_INC_DIR} ${USER_INC} )
 
 list( APPEND LINK_LIBS ${PROTOBUF_LIBRARIES} ${GLog_LIBRARIES})
-
-############################################################################
-
-# Collect all driver includes and libraries in P_INCLUDE_DIRS and P_LIBRARIES
-set_property( GLOBAL PROPERTY P_INCLUDE_DIRS ${OpenCV2_INCLUDE_DIRS} )
-set_property( GLOBAL PROPERTY P_LIBRARIES ${OpenCV2_LIBRARIES} )
 
 #############################################################################
 # HAL macros for driver writers.
@@ -75,25 +62,23 @@ macro( add_to_hal_libraries )
     foreach( lib ${ARGN} )
       # Process targets correctly
       if (TARGET ${lib})
-
-  # If the library is NOT imported, ie is in this project, we
-  # want to depend on it directly rather than through its path
-        get_target_property(is_lib_imported ${lib} IMPORTED)
-  if (NOT ${is_lib_imported})
-    set_property( GLOBAL APPEND PROPERTY P_LIBRARIES "${lib}" )
-  else()
-    # For imported targets, we just want to depend on the library directly
-          get_target_property(libpath ${lib} LOCATION)
-    if (libpath)
-            set_property( GLOBAL APPEND PROPERTY P_LIBRARIES "${libpath}" )
-
-      # This shouldn't really happen, but let's cover our bases.
-    else()
-      set_property( GLOBAL APPEND PROPERTY P_LIBRARIES "${lib}" )
-    endif()
-  endif()
+          # If the library is NOT imported, ie is in this project, we
+          # want to depend on it directly rather than through its path
+          get_target_property(is_lib_imported ${lib} IMPORTED)
+          if (NOT ${is_lib_imported})
+            set_property( GLOBAL APPEND PROPERTY P_LIBRARIES "${lib}" )
+          else()
+            # For imported targets, we just want to depend on the library directly
+            get_target_property(libpath ${lib} LOCATION)
+            if (libpath)
+                set_property( GLOBAL APPEND PROPERTY P_LIBRARIES "${libpath}" )
+              # This shouldn't really happen, but let's cover our bases.
+            else()
+                set_property( GLOBAL APPEND PROPERTY P_LIBRARIES "${lib}" )
+            endif()
+          endif()
       else()			# Just add the direct path/flag to the list
-  set_property( GLOBAL APPEND PROPERTY P_LIBRARIES "${lib}" )
+        set_property( GLOBAL APPEND PROPERTY P_LIBRARIES "${lib}" )
       endif()
     endforeach()
 
@@ -263,7 +248,7 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/config.h.in"
 
 set( GENERATED_HEADERS ${PROTO_HDRS} ${CMAKE_CURRENT_BINARY_DIR}/config.h
     ${CMAKE_CURRENT_BINARY_DIR}/ThirdParty/ThirdPartyConfig.h )
-
+    
 install_package(
     PKG_NAME HAL
     LIB_NAME hal

--- a/HAL/Camera/Drivers/Convert/CMakeLists.txt
+++ b/HAL/Camera/Drivers/Convert/CMakeLists.txt
@@ -1,11 +1,11 @@
-find_package(OpenCV2 QUIET)
+find_package(OpenCV QUIET COMPONENTS core imgproc)
 
-if(OpenCV2_FOUND)
+if(OpenCV_FOUND)
 
     message( STATUS "HAL: building 'Convert' abstract camera driver (using libopencv).")
 
-    add_to_hal_libraries( ${OpenCV2_LIBRARIES} )
-    add_to_hal_include_dirs( ${OpenCV2_INCLUDE_DIR} )
+    add_to_hal_libraries( ${OpenCV_LIBS} )
+    add_to_hal_include_dirs( ${OpenCV_INCLUDE_DIRS} )
     add_to_hal_sources(
         ConvertDriver.h ConvertDriver.cpp ConvertFactory.cpp
     )

--- a/HAL/Camera/Drivers/Convert/ConvertDriver.cpp
+++ b/HAL/Camera/Drivers/Convert/ConvertDriver.cpp
@@ -3,7 +3,9 @@
 
 #include <iostream>
 
-#include <opencv2/opencv.hpp>
+#include <opencv2/core/core.hpp>
+#include <opencv2/core/core_c.h>
+#include <opencv2/imgproc/imgproc.hpp>
 
 namespace hal
 {

--- a/HAL/Camera/Drivers/Freenect2/Freenect2Driver.cpp
+++ b/HAL/Camera/Drivers/Freenect2/Freenect2Driver.cpp
@@ -3,7 +3,7 @@
 #include <string>
 
 #include <libfreenect2/libfreenect2.hpp>
-#include <libfreenect2/threading.h>
+//#include <libfreenect2/threading.h>
 #include <libfreenect2/frame_listener_impl.h>
 
 #include <opencv2/opencv.hpp>

--- a/HAL/Camera/Drivers/OpenCV/CMakeLists.txt
+++ b/HAL/Camera/Drivers/OpenCV/CMakeLists.txt
@@ -1,17 +1,24 @@
-find_package(OpenCV2 QUIET)
+find_package(OpenCV QUIET COMPONENTS core)
 
-if(OpenCV2_FOUND)
+set(OpenCV_FOUND FALSE)
+if(OpenCV_VERSION_MAJOR EQUAL 2)
+    find_package(OpenCV QUIET COMPONENTS core imgproc highgui)
+elseif(OpenCV_VERSION_MAJOR EQUAL 3)
+    find_package(OpenCV QUIET COMPONENTS core imgproc videoio)
+endif()
+
+if(OpenCV_FOUND)
 
     set( BUILD_OpenCV true CACHE BOOL force )
 
     if(BUILD_OpenCV)
 
         message( STATUS "HAL: building 'OpenCV' camera driver.")
-        add_to_hal_libraries( ${OpenCV2_LIBRARIES} )
-        add_to_hal_include_dirs( ${OpenCV2_INCLUDE_DIR} )
+        add_to_hal_libraries( ${OpenCV_LIBS} )
+        add_to_hal_include_dirs( ${OpenCV_INCLUDE_DIRS} )
         add_to_hal_sources(
             OpenCVDriver.h OpenCVDriver.cpp OpenCVFactory.cpp
         )
-    endif()
+    endif() 
 
 endif()

--- a/HAL/Camera/Drivers/OpenCV/OpenCVDriver.cpp
+++ b/HAL/Camera/Drivers/OpenCV/OpenCVDriver.cpp
@@ -3,7 +3,6 @@
 
 #include <HAL/Utils/TicToc.h>
 
-using namespace cv;
 using namespace hal;
 
 OpenCVDriver::OpenCVDriver(unsigned int cam_id, bool force_grey)
@@ -69,7 +68,11 @@ size_t OpenCVDriver::Height(size_t /*idx*/) const {
 
 void OpenCVDriver::Initialize(){
   if (!cam_.isOpened()) abort();
-
+#if CV_VERSION_EPOCH == 2 || (!defined CV_VERSION_EPOCH && CV_VERSION_MAJOR == 2)
   img_width_ = cam_.get(CV_CAP_PROP_FRAME_WIDTH);
   img_height_ = cam_.get(CV_CAP_PROP_FRAME_HEIGHT);
+#elif CV_VERSION_MAJOR == 3
+  img_width_ = cam_.get(cv::CAP_PROP_FRAME_WIDTH);
+  img_height_ = cam_.get(cv::CAP_PROP_FRAME_HEIGHT);
+#endif
 }

--- a/HAL/Camera/Drivers/OpenCV/OpenCVDriver.h
+++ b/HAL/Camera/Drivers/OpenCV/OpenCVDriver.h
@@ -1,7 +1,17 @@
 #pragma once
 
 #include <HAL/Camera/CameraDriverInterface.h>
-#include <opencv2/opencv.hpp>
+
+#include <opencv2/core/core.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#if CV_VERSION_EPOCH == 2 || (!defined CV_VERSION_EPOCH && CV_VERSION_MAJOR == 2)
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/highgui/highgui_c.h>//constants are defined here
+#elif CV_VERSION_MAJOR == 3
+#include <opencv2/videoio/videoio.hpp>
+#endif
+
+#include <iostream>
 
 namespace hal {
 


### PR DESCRIPTION
1) Removed redundant calls to FindPackage(OpenCV ...) from HAL/CMakeLists.txt
2) Made sure OpenCV driver finds necessary OpenCV modules (different for OpenCV 2 & 3)
3) Restricted OpenCV modules used by the convert driver