### PR TITLE
added missing opencv3 imgcodecs component

### DIFF
--- a/HAL/Camera/Drivers/OpenCV/CMakeLists.txt
+++ b/HAL/Camera/Drivers/OpenCV/CMakeLists.txt
@@ -4,7 +4,7 @@ set(OpenCV_FOUND FALSE)
 if(OpenCV_VERSION_MAJOR EQUAL 2)
     find_package(OpenCV QUIET COMPONENTS core imgproc highgui)
 elseif(OpenCV_VERSION_MAJOR EQUAL 3)
-    find_package(OpenCV QUIET COMPONENTS core imgproc videoio)
+    find_package(OpenCV QUIET COMPONENTS core imgproc imgcodecs videoio)
 endif()
 
 if(OpenCV_FOUND)


### PR DESCRIPTION
one component was missing from the opencv3 cmake config, which caused the symbols for imread to be missing when the hal library was linked.