### PR TITLE
Cleaning conditional directives that break statements.

### DIFF
--- a/HAL/Camera/Drivers/Epiphan/SDK/slib/src/s_parse.c
+++ b/HAL/Camera/Drivers/Epiphan/SDK/slib/src/s_parse.c
@@ -177,14 +177,15 @@ Bool PARSE_Long(Str s, long * n, int base)
     if (s) {
         Char * endptr = NULL;
         long number;
+        Bool test;
         while (*s && IsSpace(*s)) s++;
         number = StrTol(s, &endptr, base);
         if (endptr && endptr != s) {
-            if ((number != LONG_MAX && number != LONG_MIN)
+            test = (number != LONG_MAX && number != LONG_MIN);
 #ifdef HAVE_ERRNO
-                || (errno != ERANGE)
+            test = test || (errno != ERANGE);
 #endif /* HAVE_ERRNO */
-                ) {
+            if (test) {
                 while (*endptr && IsSpace(*endptr)) endptr++;
                 if (!*endptr) {
                     if (n) *n = number;


### PR DESCRIPTION
  A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

    https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
    https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/

It might improve code understanding, maintainability and error-proneness.