### PR TITLE
Feature/openni2 autoexposure

### DIFF
--- a/HAL/Camera/Drivers/OpenNI2/OpenNI2Driver.cpp
+++ b/HAL/Camera/Drivers/OpenNI2/OpenNI2Driver.cpp
@@ -299,12 +299,33 @@ bool OpenNI2Driver::Capture( hal::CameraMsg& vImages )
   openni::Status rc;
   static double d0;
 
+  // check if exposure update needed
+  if (m_colorStream.isValid() && m_exposureUpdated)
+  {
+    std::cout << "m_exposure: " << m_exposure << std::endl;
+
+    // check if using manual exposure 
+    if ( m_exposure > 0) {
+      m_colorStream.getCameraSettings()->setAutoExposureEnabled( false );
+      m_colorStream.getCameraSettings()->setAutoWhiteBalanceEnabled( false );
+      m_colorStream.getCameraSettings()->setExposure( m_exposure );
+      m_colorStream.getCameraSettings()->setGain( m_gain );
+    }
+    // otherwise use auto-exposure 
+    else
+    {
+      m_colorStream.getCameraSettings()->setAutoExposureEnabled( true );
+      m_colorStream.getCameraSettings()->setAutoWhiteBalanceEnabled( true );
+    }
+
+    m_exposureUpdated = false;
+  }
+
   rc = openni::OpenNI::waitForAnyStream( &m_streams[0], m_streams.size(), &changedIndex );
   if (rc != openni::STATUS_OK)	{
     printf("Wait failed\n");
     return false;
   }
-
 
   if( m_streams[changedIndex] == &m_depthStream ){
     m_depthStream.readFrame(&m_depthFrame);
@@ -337,28 +358,6 @@ bool OpenNI2Driver::Capture( hal::CameraMsg& vImages )
     if( !m_colorFrame.isValid() ){
       return false;
     }
-
-    if (m_exposureUpdated)
-    {
-      std::cout << "m_exposure: " << m_exposure << std::endl;
-
-      // check if using manual exposure 
-      if ( m_exposure > 0) {
-        m_colorStream.getCameraSettings()->setAutoExposureEnabled( false );
-        m_colorStream.getCameraSettings()->setAutoWhiteBalanceEnabled( false );
-        m_colorStream.getCameraSettings()->setExposure( m_exposure );
-        m_colorStream.getCameraSettings()->setGain( m_gain );
-      }
-      // otherwise use auto-exposure 
-      else
-      {
-        m_colorStream.getCameraSettings()->setAutoExposureEnabled( true );
-        m_colorStream.getCameraSettings()->setAutoWhiteBalanceEnabled( true );
-      }
-
-      m_exposureUpdated = false;
-    }
-
   }
   if( m_depthStream.isValid() ){
     if( !m_depthFrame.isValid() ){

--- a/HAL/Camera/Drivers/OpenNI2/OpenNI2Driver.h
+++ b/HAL/Camera/Drivers/OpenNI2/OpenNI2Driver.h
@@ -27,6 +27,8 @@ class OpenNI2Driver : public CameraDriverInterface
                 bool                    bCaptureDepth,
                 bool                    bCaptureIR,
                 bool                    bAlignDepth,
+                unsigned int            nExposure,
+                unsigned int            nGain,
                 const std::string&      sn,
                 const std::string&      scmod);
 
@@ -41,6 +43,11 @@ class OpenNI2Driver : public CameraDriverInterface
         size_t NumChannels() const;
         size_t Width( size_t idx = 0 ) const;
         size_t Height( size_t idx = 0 ) const;
+        bool AutoExposure() const;
+        unsigned int Exposure() const;
+        void SetExposure(unsigned int exposure);
+        unsigned int Gain() const;
+        void SetGain(unsigned int gain);
 
     private:
 
@@ -74,6 +81,9 @@ class OpenNI2Driver : public CameraDriverInterface
         std::vector<openni::VideoStream*>    m_streams;
         std::string                          m_dev_sn;
         std::string                          m_sCameraModel;
+        unsigned int                         m_exposure;
+        unsigned int                         m_gain;
+        bool                                 m_exposureUpdated;
 };
 
 }

--- a/HAL/Camera/Drivers/OpenNI2/OpenNI2Factory.cpp
+++ b/HAL/Camera/Drivers/OpenNI2/OpenNI2Factory.cpp
@@ -17,6 +17,8 @@ public:
             {"depth", "true", "Capture depth image."},
             {"ir", "false", "Capture infrared image."},
             {"hw_align", "false", "Align depth with RGB in hardware"},
+            {"exposure", "0", "Exposure value, 0 for auto-exposure"},
+            {"gain", "0", "Camera gain"},
             {"cmod", "false", "Camera model for software aligning depth with RGB."},
 	    {"sn", "", "Open a particular S/N (first available otherwise)"},
         };
@@ -24,18 +26,21 @@ public:
 
     std::shared_ptr<CameraDriverInterface> GetDevice(const Uri& uri)
     {
-        ImageDim Dims       = uri.properties.Get("size", ImageDim(640,480));
-        unsigned int nFPS   = uri.properties.Get("fps", 30);
-        bool bRGB           = uri.properties.Get("rgb", true);
-        bool bDepth         = uri.properties.Get("depth", true);
-        bool bIR            = uri.properties.Get("ir", false);
-        bool bAlign         = uri.properties.Get("hw_align", false);
+        ImageDim Dims          = uri.properties.Get("size", ImageDim(640,480));
+        unsigned int nFPS      = uri.properties.Get("fps", 30);
+        bool bRGB              = uri.properties.Get("rgb", true);
+        bool bDepth            = uri.properties.Get("depth", true);
+        bool bIR               = uri.properties.Get("ir", false);
+        bool bAlign            = uri.properties.Get("hw_align", false);
+        unsigned int nExposure = uri.properties.Get("exposure", 0);
+        unsigned int nGain     = uri.properties.Get("gain", 0);
         std::string scmod   = uri.properties.Get<std::string>("cmod", "");
         std::string dev_sn = uri.properties.Get<std::string>("sn","");
 
         OpenNI2Driver* pDriver = new OpenNI2Driver(
-                    Dims.x, Dims.y, nFPS, bRGB, bDepth, bIR, bAlign, dev_sn, scmod
-                    );
+                    Dims.x, Dims.y, nFPS, bRGB, bDepth, bIR, bAlign,
+                    nExposure, nGain, dev_sn, scmod);
+
         return std::shared_ptr<CameraDriverInterface>( pDriver );
     }
 };


### PR DESCRIPTION
This extends the OpenNI2Driver interface to support setting the exposure & gain. However it seems one cannot set the exposure from the hal::OpenNI2Driver constructor (auto-exposure can be disabled, but the default exposure value will *always* be used). For this reason, the current approach is to set the exposure once from inside the Capture method.