### PR TITLE
Fix/race condition

### DIFF
--- a/HAL/Devices/DeviceTime.cpp
+++ b/HAL/Devices/DeviceTime.cpp
@@ -54,7 +54,7 @@ void ResetTime()
 ////////////////////////////////////////////////////////////////////////////////
 double NextTime()
 {
-    std::lock_guard<std::mutex> lock(MUTEX);
+    //std::lock_guard<std::mutex> lock(MUTEX);
     if( QUEUE.empty() ) {
         return 0;
     } else {
@@ -66,10 +66,9 @@ double NextTime()
 void WaitForTime(double nextTime)
 {
     // check if timestamp is the top of the queue
-    while( NextTime() < nextTime ) {
-      std::unique_lock<std::mutex> lock(MUTEX);
-      CONDVAR.wait( lock );
-    }
+    // if not, wait until the older timestamp is popped by another thread.
+    std::unique_lock<std::mutex> lock(MUTEX);
+    CONDVAR.wait( lock, [=]{return  NextTime() >= nextTime;});
 
     // TODO: Sleep for appropriate amount of time.
     if(REALTIME) {

--- a/HAL/Posys/Drivers/Csv/CsvPosysDriver.cpp
+++ b/HAL/Posys/Drivers/Csv/CsvPosysDriver.cpp
@@ -109,6 +109,8 @@ void CsvPosysDriver::_ThreadCaptureFunc()
 
         // break if EOF
         if( _GetNextTime( m_dNextTime, m_dNextTimePPS ) == false ) {
+            // Pop the last measurement so it does not hold up the queue
+            hal::DeviceTime::PopTime();
             break;
         }
 


### PR DESCRIPTION
When using two Posys devices, using the CsvPosysDriver, a race condition happened in "WaitForTime". Also the EOF condition was not popping the last timestamp causing the queue (and any other threads) to block indefinitely.