### PR TITLE
Feature/realsense driver

### DIFF
--- a/HAL/Camera/Drivers/OpenNI2/OpenNI2Driver.cpp
+++ b/HAL/Camera/Drivers/OpenNI2/OpenNI2Driver.cpp
@@ -320,7 +320,6 @@ bool OpenNI2Driver::Capture( hal::CameraMsg& vImages )
         ++m_frame;
       }
 
-      std::cout << "e: " << exposure << ", g: " << gain << std::endl;
       m_colorStream.getCameraSettings()->setGain( gain );
       m_colorStream.getCameraSettings()->setExposure( exposure );
       m_colorStream.getCameraSettings()->setAutoExposureEnabled( false );

--- a/HAL/Camera/Drivers/RealSense2/CMakeLists.txt
+++ b/HAL/Camera/Drivers/RealSense2/CMakeLists.txt
@@ -1,0 +1,18 @@
+find_package(RealSense2 QUIET)
+option(BUILD_RealSense2 "Build RealSense2 Driver." ON)
+
+if(RealSense2_FOUND AND BUILD_RealSense2)
+
+  message(STATUS "HAL: building 'RealSense2' camera driver.")
+
+  set(SOURCES
+    RealSense2Driver.h
+    RealSense2Driver.cpp
+    RealSense2Factory.cpp
+  )
+
+  add_to_hal_include_dirs(${RealSense2_INCLUDE_DIRS})
+  add_to_hal_libraries(${RealSense2_LIBRARIES})
+  add_to_hal_sources(${SOURCES})
+
+endif()

--- a/HAL/Camera/Drivers/RealSense2/RealSense2Driver.cpp
+++ b/HAL/Camera/Drivers/RealSense2/RealSense2Driver.cpp
@@ -1,0 +1,338 @@
+#include "RealSense2Driver.h"
+#include <iostream>
+
+namespace hal
+{
+
+RealSense2Driver::RealSense2Driver(int width, int height, int frame_rate,
+    bool capture_color, bool capture_depth, bool capture_ir0, bool capture_ir1,
+    bool emit_ir, double exposure, double gain) :
+  width_(width),
+  height_(height),
+  capture_color_(capture_color),
+  capture_depth_(capture_depth),
+  capture_ir0_(capture_ir0),
+  capture_ir1_(capture_ir1),
+  emit_ir_(emit_ir),
+  frame_rate_(frame_rate),
+  exposure_(exposure),
+  gain_(gain)
+{
+  Initialize();
+}
+
+RealSense2Driver::~RealSense2Driver()
+{
+}
+
+bool RealSense2Driver::Capture(CameraMsg& images)
+{
+  rs2::frameset frameset = pipeline_->wait_for_frames();
+  images.set_device_time(frameset.get_timestamp());
+
+  if (capture_color_)
+  {
+    ImageMsg* image = images.add_image();
+    rs2::video_frame frame = frameset.get_color_frame();
+    const size_t bytes = frame.get_stride_in_bytes() * frame.get_height();
+    image->set_width(frame.get_width());
+    image->set_height(frame.get_height());
+    image->set_data(frame.get_data(), bytes);
+    image->set_type(PB_UNSIGNED_BYTE);
+    image->set_format(PB_RGB);
+  }
+
+  if (capture_depth_)
+  {
+    ImageMsg* image = images.add_image();
+    rs2::video_frame frame = frameset.get_depth_frame();
+    const size_t bytes = frame.get_stride_in_bytes() * frame.get_height();
+    image->set_width(frame.get_width());
+    image->set_height(frame.get_height());
+    image->set_data(frame.get_data(), bytes);
+    image->set_format(PB_LUMINANCE);
+    image->set_type(PB_SHORT);
+  }
+
+  if (capture_ir0_)
+  {
+    ImageMsg* image = images.add_image();
+    rs2::video_frame frame = frameset.get_infrared_frame(1);
+    const size_t bytes = frame.get_stride_in_bytes() * frame.get_height();
+    image->set_width(frame.get_width());
+    image->set_height(frame.get_height());
+    image->set_data(frame.get_data(), bytes);
+    image->set_format(PB_LUMINANCE);
+    // image->set_type(PB_UNSIGNED_BYTE);
+    image->set_type(PB_UNSIGNED_SHORT);
+  }
+
+  if (capture_ir1_)
+  {
+    ImageMsg* image = images.add_image();
+    rs2::video_frame frame = frameset.get_infrared_frame(2);
+    const size_t bytes = frame.get_stride_in_bytes() * frame.get_height();
+    image->set_width(frame.get_width());
+    image->set_height(frame.get_height());
+    image->set_data(frame.get_data(), bytes);
+    image->set_format(PB_LUMINANCE);
+    // image->set_type(PB_UNSIGNED_BYTE);
+    image->set_type(PB_UNSIGNED_SHORT);
+  }
+
+  return true;
+}
+
+std::shared_ptr<CameraDriverInterface> RealSense2Driver::GetInputDevice()
+{
+  return std::shared_ptr<CameraDriverInterface>();
+}
+
+std::string RealSense2Driver::GetDeviceProperty(const std::string& property)
+{
+  return "";
+}
+
+size_t RealSense2Driver::NumChannels() const
+{
+  return streams_.size();
+}
+
+size_t RealSense2Driver::Width(size_t index) const
+{
+  return streams_[index].width();
+}
+
+size_t RealSense2Driver::Height(size_t index) const
+{
+  return streams_[index].height();
+}
+
+bool RealSense2Driver::AutoExposure() const
+{
+  return exposure_ <= 0;
+}
+
+double RealSense2Driver::Exposure() const
+{
+  return exposure_;
+}
+
+void RealSense2Driver::SetExposure(double exposure)
+{
+  exposure_ = exposure;
+
+  rs2::pipeline_profile pipeline_profile = pipeline_->get_active_profile();
+  std::vector<rs2::sensor> sensors = pipeline_profile.get_device().query_sensors();
+
+  for (rs2::sensor sensor: sensors)
+  {
+    if (!sensor.is<rs2::depth_sensor>())
+    {
+      if (exposure_ > 0)
+      {
+        sensor.set_option(RS2_OPTION_BACKLIGHT_COMPENSATION, false);
+        sensor.set_option(RS2_OPTION_ENABLE_AUTO_EXPOSURE, false);
+        sensor.set_option(RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE, false);
+        sensor.set_option(RS2_OPTION_WHITE_BALANCE, 3500);
+        sensor.set_option(RS2_OPTION_EXPOSURE, exposure_);
+        sensor.set_option(RS2_OPTION_GAIN, gain_);
+        sensor.set_option(RS2_OPTION_GAMMA, 300);
+        sensor.set_option(RS2_OPTION_HUE, 0);
+        sensor.set_option(RS2_OPTION_SATURATION, 68);
+      }
+      else
+      {
+        sensor.set_option(RS2_OPTION_BACKLIGHT_COMPENSATION, true);
+        sensor.set_option(RS2_OPTION_ENABLE_AUTO_EXPOSURE, true);
+        sensor.set_option(RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE, true);
+      }
+    }
+  }
+}
+
+double RealSense2Driver::Gain() const
+{
+  return gain_;
+}
+
+void RealSense2Driver::SetGain(double gain)
+{
+  gain_ = gain;
+
+  rs2::pipeline_profile pipeline_profile = pipeline_->get_active_profile();
+  std::vector<rs2::sensor> sensors = pipeline_profile.get_device().query_sensors();
+
+  for (rs2::sensor sensor: sensors)
+  {
+    if (!sensor.is<rs2::depth_sensor>())
+    {
+      sensor.set_option(RS2_OPTION_GAIN, gain_);
+    }
+  }
+}
+
+void RealSense2Driver::Initialize()
+{
+  CreatePipeline();
+  ConfigurePipeline();
+  CreateStreams();
+}
+
+void RealSense2Driver::CreatePipeline()
+{
+  rs2::pipeline* pointer = new rs2::pipeline;
+  pipeline_ = std::unique_ptr<rs2::pipeline>(pointer);
+}
+
+void RealSense2Driver::ConfigurePipeline()
+{
+  rs2::config configuration;
+  configuration.disable_all_streams();
+
+  if (capture_color_)
+  {
+    configuration.enable_stream(RS2_STREAM_COLOR, width_, height_, RS2_FORMAT_ANY, frame_rate_);
+    // configuration.enable_stream(RS2_STREAM_COLOR, 1920, 1080, RS2_FORMAT_ANY, frame_rate_);
+  }
+
+  if (capture_depth_)
+  {
+    configuration.enable_stream(RS2_STREAM_DEPTH, width_, height_, RS2_FORMAT_ANY, frame_rate_);
+  }
+
+  if (capture_ir0_)
+  {
+    configuration.enable_stream(RS2_STREAM_INFRARED, 1, width_, height_, RS2_FORMAT_ANY, frame_rate_);
+  }
+
+  if (capture_ir1_)
+  {
+    configuration.enable_stream(RS2_STREAM_INFRARED, 2, width_, height_, RS2_FORMAT_ANY, frame_rate_);
+  }
+
+  pipeline_->start(configuration);
+}
+
+void RealSense2Driver::CreateStreams()
+{
+  rs2::pipeline_profile pipeline_profile = pipeline_->get_active_profile();
+  std::vector<rs2::sensor> sensors = pipeline_profile.get_device().query_sensors();
+
+  for (rs2::sensor sensor: sensors)
+  {
+    const int count = RS2_OPTION_COUNT;
+
+    for (int i = 0; i < count; ++i)
+    {
+      const rs2_option option = rs2_option(i);
+
+      if (!sensor.supports(option) ||
+          sensor.is_option_read_only(option) ||
+          option == RS2_OPTION_POWER_LINE_FREQUENCY ||
+          option == RS2_OPTION_EXPOSURE)
+      {
+        continue;
+      }
+
+      const rs2::option_range range = sensor.get_option_range(option);
+
+      std::cout << "Option: " << rs2_option_to_string(option) << " -> " << range.def << std::endl;
+
+      // const float value = sensor.get_option(option);
+      // const std::string desc = sensor.get_option_description(option);
+      // // const std::string value_desc = sensor.get_option_value_description(option, value);
+
+      // std::cout << "  Description:   " << desc << std::endl;
+      // std::cout << "  Current value: " << value << std::endl;
+      // // std::cout << "  Current desc:  " << value_desc << std::endl;
+      // std::cout << "  Value range:   " << range.min << ".." << range.max << std::endl;
+      // std::cout << "  Value default: " << range.def << std::endl;
+      // std::cout << "  Value step:    " << range.step << std::endl;
+
+      sensor.set_option(option, range.def);
+    }
+
+    if (sensor.is<rs2::depth_sensor>())
+    {
+      rs2::depth_sensor depth_sensor = sensor.as<rs2::depth_sensor>();
+      depth_sensor.set_option(RS2_OPTION_EMITTER_ENABLED, emit_ir_);
+    }
+    else
+    {
+      if (exposure_ > 0)
+      {
+        sensor.set_option(RS2_OPTION_BACKLIGHT_COMPENSATION, false);
+        sensor.set_option(RS2_OPTION_ENABLE_AUTO_EXPOSURE, false);
+        sensor.set_option(RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE, false);
+        sensor.set_option(RS2_OPTION_WHITE_BALANCE, 3500);
+        sensor.set_option(RS2_OPTION_EXPOSURE, exposure_);
+        sensor.set_option(RS2_OPTION_GAIN, gain_);
+        sensor.set_option(RS2_OPTION_GAMMA, 300);
+        sensor.set_option(RS2_OPTION_HUE, 0);
+        sensor.set_option(RS2_OPTION_SATURATION, 68);
+      }
+    }
+  }
+
+  if (capture_color_)
+  {
+    rs2::stream_profile stream = pipeline_profile.get_stream(RS2_STREAM_COLOR);
+    streams_.push_back(stream.as<rs2::video_stream_profile>());
+
+    printf("Color calibration (%s):\n", streams_.back().stream_name().c_str());
+
+    printf("  fx: %f, fy: %f, cx: %f, cy: %f\n",
+        streams_.back().get_intrinsics().fx,
+        streams_.back().get_intrinsics().fy,
+        streams_.back().get_intrinsics().ppx,
+        streams_.back().get_intrinsics().ppy);
+
+    printf("  distortion model type:   %d\n", (int)streams_.back().get_intrinsics().model);
+
+    printf("  distortion model params: %f %f %f %f %f\n",
+        streams_.back().get_intrinsics().coeffs[0],
+        streams_.back().get_intrinsics().coeffs[1],
+        streams_.back().get_intrinsics().coeffs[2],
+        streams_.back().get_intrinsics().coeffs[3],
+        streams_.back().get_intrinsics().coeffs[4]);
+  }
+
+  if (capture_depth_)
+  {
+    rs2::stream_profile stream = pipeline_profile.get_stream(RS2_STREAM_DEPTH);
+    streams_.push_back(stream.as<rs2::video_stream_profile>());
+
+    printf("Depth calibration (%s):\n", streams_.back().stream_name().c_str());
+
+    printf("  fx: %f, fy: %f, cx: %f, cy: %f\n",
+        streams_.back().get_intrinsics().fx,
+        streams_.back().get_intrinsics().fy,
+        streams_.back().get_intrinsics().ppx,
+        streams_.back().get_intrinsics().ppy);
+
+    printf("  distortion model type:   %d\n", (int)streams_.back().get_intrinsics().model);
+
+    printf("  distortion model params: %f %f %f %f %f\n",
+        streams_.back().get_intrinsics().coeffs[0],
+        streams_.back().get_intrinsics().coeffs[1],
+        streams_.back().get_intrinsics().coeffs[2],
+        streams_.back().get_intrinsics().coeffs[3],
+        streams_.back().get_intrinsics().coeffs[4]);
+  }
+
+  if (capture_ir0_)
+  {
+    rs2::stream_profile stream = pipeline_profile.get_stream(RS2_STREAM_INFRARED, 1);
+    streams_.push_back(stream.as<rs2::video_stream_profile>());
+  }
+
+  if (capture_ir1_)
+  {
+    rs2::stream_profile stream = pipeline_profile.get_stream(RS2_STREAM_INFRARED, 2);
+    streams_.push_back(stream.as<rs2::video_stream_profile>());
+  }
+}
+
+
+} // namespace hal

--- a/HAL/Camera/Drivers/RealSense2/RealSense2Driver.cpp
+++ b/HAL/Camera/Drivers/RealSense2/RealSense2Driver.cpp
@@ -5,18 +5,15 @@ namespace hal
 {
 
 RealSense2Driver::RealSense2Driver(int width, int height, int frame_rate,
-    bool capture_color, bool capture_depth, bool capture_ir0, bool capture_ir1,
-    bool emit_ir, double exposure, double gain) :
+    bool capture_color, bool capture_depth, bool capture_ir0,
+    bool capture_ir1) :
   width_(width),
   height_(height),
   capture_color_(capture_color),
   capture_depth_(capture_depth),
   capture_ir0_(capture_ir0),
   capture_ir1_(capture_ir1),
-  emit_ir_(emit_ir),
-  frame_rate_(frame_rate),
-  exposure_(exposure),
-  gain_(gain)
+  frame_rate_(frame_rate)
 {
   Initialize();
 }
@@ -27,57 +24,12 @@ RealSense2Driver::~RealSense2Driver()
 
 bool RealSense2Driver::Capture(CameraMsg& images)
 {
-  rs2::frameset frameset = pipeline_->wait_for_frames();
-  images.set_device_time(frameset.get_timestamp());
-
-  if (capture_ir0_)
-  {
-    ImageMsg* image = images.add_image();
-    rs2::video_frame frame = frameset.get_infrared_frame(1);
-    const size_t bytes = frame.get_stride_in_bytes() * frame.get_height();
-    image->set_width(frame.get_width());
-    image->set_height(frame.get_height());
-    image->set_data(frame.get_data(), bytes);
-    image->set_format(PB_LUMINANCE);
-    image->set_type(PB_UNSIGNED_BYTE);
-  }
-
-  if (capture_ir1_)
-  {
-    ImageMsg* image = images.add_image();
-    rs2::video_frame frame = frameset.get_infrared_frame(2);
-    const size_t bytes = frame.get_stride_in_bytes() * frame.get_height();
-    image->set_width(frame.get_width());
-    image->set_height(frame.get_height());
-    image->set_data(frame.get_data(), bytes);
-    image->set_format(PB_LUMINANCE);
-    image->set_type(PB_UNSIGNED_BYTE);
-  }
-
-  if (capture_color_)
-  {
-    ImageMsg* image = images.add_image();
-    rs2::video_frame frame = frameset.get_color_frame();
-    const size_t bytes = frame.get_stride_in_bytes() * frame.get_height();
-    image->set_width(frame.get_width());
-    image->set_height(frame.get_height());
-    image->set_data(frame.get_data(), bytes);
-    image->set_type(PB_UNSIGNED_BYTE);
-    image->set_format(PB_RGB);
-  }
-
-  if (capture_depth_)
-  {
-    ImageMsg* image = images.add_image();
-    rs2::video_frame frame = frameset.get_depth_frame();
-    const size_t bytes = frame.get_stride_in_bytes() * frame.get_height();
-    image->set_width(frame.get_width());
-    image->set_height(frame.get_height());
-    image->set_data(frame.get_data(), bytes);
-    image->set_format(PB_LUMINANCE);
-    image->set_type(PB_SHORT);
-  }
-
+  frameset_ = pipeline_->wait_for_frames();
+  images.set_device_time(frameset_.get_timestamp());
+  if (capture_ir0_) CaptureInfraredStream(1, images);
+  if (capture_ir1_) CaptureInfraredStream(2, images);
+  if (capture_color_) CaptureColorStream(images);
+  if (capture_depth_) CaptureDepthStream(images);
   return true;
 }
 
@@ -86,7 +38,7 @@ std::shared_ptr<CameraDriverInterface> RealSense2Driver::GetInputDevice()
   return std::shared_ptr<CameraDriverInterface>();
 }
 
-std::string RealSense2Driver::GetDeviceProperty(const std::string& property)
+std::string RealSense2Driver::GetDeviceProperty(const std::string&)
 {
   return "";
 }
@@ -106,91 +58,187 @@ size_t RealSense2Driver::Height(size_t index) const
   return streams_[index].height();
 }
 
-bool RealSense2Driver::AutoExposure() const
+double RealSense2Driver::MaxExposure(int channel) const
 {
-  return exposure_ <= 0;
+  const rs2_option option = RS2_OPTION_EXPOSURE;
+  const rs2::sensor& sensor = GetSensor(channel);
+  const rs2::option_range range = sensor.get_option_range(option);
+  return range.max;
 }
 
-double RealSense2Driver::Exposure() const
+double RealSense2Driver::MinExposure(int channel) const
 {
-  rs2::pipeline_profile pipeline_profile = pipeline_->get_active_profile();
-  std::vector<rs2::sensor> sensors = pipeline_profile.get_device().query_sensors();
-
-  for (rs2::sensor sensor: sensors)
-  {
-    if (!sensor.is<rs2::depth_sensor>())
-    {
-      return sensor.get_option(RS2_OPTION_EXPOSURE);
-    }
-  }
-
-  return exposure_;
+  const rs2_option option = RS2_OPTION_EXPOSURE;
+  const rs2::sensor& sensor = GetSensor(channel);
+  const rs2::option_range range = sensor.get_option_range(option);
+  return range.min;
 }
 
-void RealSense2Driver::SetExposure(double exposure)
+double RealSense2Driver::MaxGain(int channel) const
 {
-  exposure_ = exposure;
-
-  rs2::pipeline_profile pipeline_profile = pipeline_->get_active_profile();
-  std::vector<rs2::sensor> sensors = pipeline_profile.get_device().query_sensors();
-
-  for (rs2::sensor sensor: sensors)
-  {
-    if (!sensor.is<rs2::depth_sensor>())
-    {
-      std::cout.flush();
-
-      if (exposure_ > 0)
-      {
-        sensor.set_option(RS2_OPTION_BACKLIGHT_COMPENSATION, false);
-        sensor.set_option(RS2_OPTION_ENABLE_AUTO_EXPOSURE, false);
-        sensor.set_option(RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE, false);
-        sensor.set_option(RS2_OPTION_WHITE_BALANCE, 3500);
-        sensor.set_option(RS2_OPTION_EXPOSURE, exposure_);
-        sensor.set_option(RS2_OPTION_GAIN, gain_);
-        sensor.set_option(RS2_OPTION_GAMMA, 300);
-        sensor.set_option(RS2_OPTION_HUE, 0);
-        sensor.set_option(RS2_OPTION_SATURATION, 68);
-      }
-      else
-      {
-        sensor.set_option(RS2_OPTION_BACKLIGHT_COMPENSATION, true);
-        sensor.set_option(RS2_OPTION_ENABLE_AUTO_EXPOSURE, true);
-        sensor.set_option(RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE, true);
-      }
-    }
-    else
-    {
-      std::cout.flush();
-    }
-  }
+  const rs2_option option = RS2_OPTION_GAIN;
+  const rs2::sensor& sensor = GetSensor(channel);
+  const rs2::option_range range = sensor.get_option_range(option);
+  return range.max;
 }
 
-double RealSense2Driver::Gain() const
+double RealSense2Driver::MinGain(int channel) const
 {
-  return gain_;
+  const rs2_option option = RS2_OPTION_GAIN;
+  const rs2::sensor& sensor = GetSensor(channel);
+  const rs2::option_range range = sensor.get_option_range(option);
+  return range.min;
 }
 
-void RealSense2Driver::SetGain(double gain)
+double RealSense2Driver::Exposure(int channel)
+{
+  const rs2_option option = RS2_OPTION_EXPOSURE;
+  const rs2::sensor& sensor = GetSensor(channel);
+  return sensor.get_option(option);
+}
+
+void RealSense2Driver::SetExposure(double exposure, int channel)
+{
+  (exposure > 0) ?
+      DisableAutoExposure(channel, exposure) :
+      EnableAutoExposure(channel);
+}
+
+double RealSense2Driver::Gain(int channel)
+{
+  const rs2_option option = RS2_OPTION_GAIN;
+  const rs2::sensor& sensor = GetSensor(channel);
+  return sensor.get_option(option);
+}
+
+void RealSense2Driver::SetGain(double gain, int channel)
 {
   gain_ = gain;
+  const rs2_option option = RS2_OPTION_GAIN;
+  const rs2::sensor& sensor = GetSensor(channel);
+  sensor.set_option(option, gain_);
+}
 
-  rs2::pipeline_profile pipeline_profile = pipeline_->get_active_profile();
-  std::vector<rs2::sensor> sensors = pipeline_profile.get_device().query_sensors();
+double RealSense2Driver::ProportionalGain(int channel) const
+{
+  return IsColorStream(channel) ? 0.45 : 2.5;
+}
 
-  for (rs2::sensor sensor: sensors)
+double RealSense2Driver::IntegralGain(int channel) const
+{
+  return IsColorStream(channel) ? 0.01 : 0.1;
+}
+
+double RealSense2Driver::DerivativeGain(int channel) const
+{
+  return IsColorStream(channel) ? 0.5 : 3.0;
+}
+
+double RealSense2Driver::Emitter() const
+{
+  if (depth_sensor_.get_option(RS2_OPTION_EMITTER_ENABLED))
   {
-    if (!sensor.is<rs2::depth_sensor>())
-    {
-      sensor.set_option(RS2_OPTION_GAIN, gain_);
-    }
+    const rs2_option option = RS2_OPTION_LASER_POWER;
+    const double value = depth_sensor_.get_option(option);
+    const rs2::option_range range = depth_sensor_.get_option_range(option);
+    return (value - range.min) / (range.max - range.min);
   }
+
+  return 0.0;
+}
+
+void RealSense2Driver::SetEmitter(double emitter) const
+{
+  emitter = std::max(0.0, std::min(1.0, emitter));
+  const rs2_option option = RS2_OPTION_LASER_POWER;
+  depth_sensor_.set_option(RS2_OPTION_EMITTER_ENABLED, emitter <= 0.0);
+  const rs2::option_range range = depth_sensor_.get_option_range(option);
+  emitter = range.min + emitter * (range.max - range.min);
+  depth_sensor_.set_option(option, emitter);
+}
+
+void RealSense2Driver::EnableAutoExposure(int channel)
+{
+  rs2::sensor& sensor = GetSensor(channel);
+  sensor.set_option(RS2_OPTION_ENABLE_AUTO_EXPOSURE, true);
+
+  if (IsColorStream(channel))
+  {
+    sensor.set_option(RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE, true);
+    sensor.set_option(RS2_OPTION_BACKLIGHT_COMPENSATION, true);
+  }
+}
+
+void RealSense2Driver::DisableAutoExposure(int channel, double exposure)
+{
+  rs2::sensor& sensor = GetSensor(channel);
+  sensor.set_option(RS2_OPTION_ENABLE_AUTO_EXPOSURE, false);
+  sensor.set_option(RS2_OPTION_EXPOSURE, exposure);
+
+  if (IsColorStream(channel))
+  {
+    sensor.set_option(RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE, false);
+    sensor.set_option(RS2_OPTION_BACKLIGHT_COMPENSATION, false);
+    sensor.set_option(RS2_OPTION_WHITE_BALANCE, 3250);
+  }
+}
+
+void RealSense2Driver::CaptureInfraredStream(int index, CameraMsg& images)
+{
+  ImageMsg* image = images.add_image();
+  rs2::video_frame frame = frameset_.get_infrared_frame(index);
+  const size_t bytes = frame.get_stride_in_bytes() * frame.get_height();
+  image->set_width(frame.get_width());
+  image->set_height(frame.get_height());
+  image->set_data(frame.get_data(), bytes);
+  image->set_format(PB_LUMINANCE);
+  image->set_type(PB_UNSIGNED_BYTE);
+}
+
+void RealSense2Driver::CaptureColorStream(CameraMsg& images)
+{
+  ImageMsg* image = images.add_image();
+  rs2::video_frame frame = frameset_.get_color_frame();
+  const size_t bytes = frame.get_stride_in_bytes() * frame.get_height();
+  image->set_width(frame.get_width());
+  image->set_height(frame.get_height());
+  image->set_data(frame.get_data(), bytes);
+  image->set_type(PB_UNSIGNED_BYTE);
+  image->set_format(PB_RGB);
+}
+
+void RealSense2Driver::CaptureDepthStream(CameraMsg& images)
+{
+  ImageMsg* image = images.add_image();
+  rs2::video_frame frame = frameset_.get_depth_frame();
+  const size_t bytes = frame.get_stride_in_bytes() * frame.get_height();
+  image->set_width(frame.get_width());
+  image->set_height(frame.get_height());
+  image->set_data(frame.get_data(), bytes);
+  image->set_format(PB_LUMINANCE);
+  image->set_type(PB_SHORT);
+}
+
+bool RealSense2Driver::IsColorStream(int channel) const
+{
+  return streams_[channel].stream_type() == RS2_STREAM_COLOR;
+}
+
+const rs2::sensor& RealSense2Driver::GetSensor(int channel) const
+{
+  return IsColorStream(channel) ? color_sensor_ : depth_sensor_;
+}
+
+rs2::sensor&RealSense2Driver::GetSensor(int channel)
+{
+  return IsColorStream(channel) ? color_sensor_ : depth_sensor_;
 }
 
 void RealSense2Driver::Initialize()
 {
   CreatePipeline();
   ConfigurePipeline();
+  CreateSensors();
   CreateStreams();
 }
 
@@ -202,158 +250,85 @@ void RealSense2Driver::CreatePipeline()
 
 void RealSense2Driver::ConfigurePipeline()
 {
-  rs2::config configuration;
-  configuration.disable_all_streams();
+  CreateConfiguration();
+  if (capture_ir0_) ConfigureInfraredStream(1);
+  if (capture_ir1_) ConfigureInfraredStream(2);
+  if (capture_color_) ConfigureColorStream();
+  if (capture_depth_) ConfigureDepthStream();
+  pipeline_->start(*configuration_);
+}
 
-  if (capture_color_)
+void RealSense2Driver::CreateConfiguration()
+{
+  rs2::config* pointer = new rs2::config();
+  configuration_ = std::unique_ptr<rs2::config>(pointer);
+  configuration_->disable_all_streams();
+}
+
+void RealSense2Driver::ConfigureInfraredStream(int index)
+{
+  const int rate = frame_rate_;
+  const rs2_format format = RS2_FORMAT_Y8;
+  const rs2_stream stream = RS2_STREAM_INFRARED;
+  configuration_->enable_stream(stream, index, width_, height_, format, rate);
+}
+
+void RealSense2Driver::ConfigureColorStream()
+{
+  const int rate = frame_rate_;
+  const rs2_format format = RS2_FORMAT_RGB8;
+  const rs2_stream stream = RS2_STREAM_COLOR;
+  configuration_->enable_stream(stream, width_, height_, format, rate);
+}
+
+void RealSense2Driver::ConfigureDepthStream()
+{
+  const int rate = frame_rate_;
+  const rs2_format format = RS2_FORMAT_Z16;
+  const rs2_stream stream = RS2_STREAM_DEPTH;
+  configuration_->enable_stream(stream, width_, height_, format, rate);
+}
+
+void RealSense2Driver::CreateSensors()
+{
+  rs2::pipeline_profile pipeline_profile = pipeline_->get_active_profile();
+  const rs2::device device = pipeline_profile.get_device();
+  std::vector<rs2::sensor> sensors = device.query_sensors();
+
+  for (rs2::sensor sensor: sensors)
   {
-    configuration.enable_stream(RS2_STREAM_COLOR, width_, height_, RS2_FORMAT_RGB8, frame_rate_);
-    // configuration.enable_stream(RS2_STREAM_COLOR, 1920, 1080, RS2_FORMAT_RGB8, frame_rate_);
+    (sensor.is<rs2::depth_sensor>()) ?
+        depth_sensor_ = sensor : color_sensor_ = sensor;
   }
-
-  if (capture_depth_)
-  {
-    configuration.enable_stream(RS2_STREAM_DEPTH, width_, height_, RS2_FORMAT_Z16, frame_rate_);
-  }
-
-  if (capture_ir0_)
-  {
-    configuration.enable_stream(RS2_STREAM_INFRARED, 1, width_, height_, RS2_FORMAT_Y8, frame_rate_);
-  }
-
-  if (capture_ir1_)
-  {
-    configuration.enable_stream(RS2_STREAM_INFRARED, 2, width_, height_, RS2_FORMAT_Y8, frame_rate_);
-  }
-
-  pipeline_->start(configuration);
 }
 
 void RealSense2Driver::CreateStreams()
 {
-  rs2::pipeline_profile pipeline_profile = pipeline_->get_active_profile();
-  std::vector<rs2::sensor> sensors = pipeline_profile.get_device().query_sensors();
+  if (capture_ir0_) CreateInfraredStream(1);
+  if (capture_ir1_) CreateInfraredStream(2);
+  if (capture_color_) CreateColorStream();
+  if (capture_depth_) CreateDepthStream();
+}
 
-  for (rs2::sensor sensor: sensors)
-  {
-    const int count = RS2_OPTION_COUNT;
+void RealSense2Driver::CreateInfraredStream(int index)
+{
+  rs2::pipeline_profile profile = pipeline_->get_active_profile();
+  rs2::stream_profile stream = profile.get_stream(RS2_STREAM_INFRARED, index);
+  streams_.push_back(stream.as<rs2::video_stream_profile>());
+}
 
-    for (int i = 0; i < count; ++i)
-    {
-      const rs2_option option = rs2_option(i);
+void RealSense2Driver::CreateColorStream()
+{
+  rs2::pipeline_profile profile = pipeline_->get_active_profile();
+  rs2::stream_profile stream = profile.get_stream(RS2_STREAM_COLOR);
+  streams_.push_back(stream.as<rs2::video_stream_profile>());
+}
 
-      if (!sensor.supports(option) ||
-          sensor.is_option_read_only(option) ||
-          option == RS2_OPTION_POWER_LINE_FREQUENCY ||
-          option == RS2_OPTION_EXPOSURE)
-      {
-        continue;
-      }
-
-      const rs2::option_range range = sensor.get_option_range(option);
-
-      std::cout << "Option: " << rs2_option_to_string(option) << " -> " << range.def << std::endl;
-
-      // const float value = sensor.get_option(option);
-      // const std::string desc = sensor.get_option_description(option);
-      // // const std::string value_desc = sensor.get_option_value_description(option, value);
-
-      // std::cout << "  Description:   " << desc << std::endl;
-      // std::cout << "  Current value: " << value << std::endl;
-      // // std::cout << "  Current desc:  " << value_desc << std::endl;
-      std::cout << "  Value range:   " << range.min << ".." << range.max << std::endl;
-      // std::cout << "  Value default: " << range.def << std::endl;
-      // std::cout << "  Value step:    " << range.step << std::endl;
-
-      sensor.set_option(option, range.def);
-    }
-
-    if (sensor.is<rs2::depth_sensor>())
-    {
-      std::cout << "====== no exp name: " << sensor.get_info(RS2_CAMERA_INFO_NAME) << std::endl;
-      rs2::depth_sensor depth_sensor = sensor.as<rs2::depth_sensor>();
-      depth_sensor.set_option(RS2_OPTION_EMITTER_ENABLED, emit_ir_);
-
-      if (emit_ir_)
-      {
-        depth_sensor.set_option(RS2_OPTION_LASER_POWER, 360);
-      }
-    }
-    else
-    {
-      std::cout << "====== exp name: " << sensor.get_info(RS2_CAMERA_INFO_NAME) << std::endl;
-      if (exposure_ > 0)
-      {
-        sensor.set_option(RS2_OPTION_BACKLIGHT_COMPENSATION, false);
-        sensor.set_option(RS2_OPTION_ENABLE_AUTO_EXPOSURE, false);
-        sensor.set_option(RS2_OPTION_ENABLE_AUTO_WHITE_BALANCE, false);
-        sensor.set_option(RS2_OPTION_WHITE_BALANCE, 3500);
-        sensor.set_option(RS2_OPTION_EXPOSURE, exposure_);
-        sensor.set_option(RS2_OPTION_GAIN, gain_);
-        sensor.set_option(RS2_OPTION_GAMMA, 300);
-        sensor.set_option(RS2_OPTION_HUE, 0);
-        sensor.set_option(RS2_OPTION_SATURATION, 68);
-      }
-    }
-  }
-
-  if (capture_color_)
-  {
-    rs2::stream_profile stream = pipeline_profile.get_stream(RS2_STREAM_COLOR);
-    streams_.push_back(stream.as<rs2::video_stream_profile>());
-
-    printf("Color calibration (%s):\n", streams_.back().stream_name().c_str());
-
-    printf("  fx: %f, fy: %f, cx: %f, cy: %f\n",
-        streams_.back().get_intrinsics().fx,
-        streams_.back().get_intrinsics().fy,
-        streams_.back().get_intrinsics().ppx,
-        streams_.back().get_intrinsics().ppy);
-
-    printf("  distortion model type:   %d\n", (int)streams_.back().get_intrinsics().model);
-
-    printf("  distortion model params: %f %f %f %f %f\n",
-        streams_.back().get_intrinsics().coeffs[0],
-        streams_.back().get_intrinsics().coeffs[1],
-        streams_.back().get_intrinsics().coeffs[2],
-        streams_.back().get_intrinsics().coeffs[3],
-        streams_.back().get_intrinsics().coeffs[4]);
-  }
-
-  if (capture_depth_)
-  {
-    rs2::stream_profile stream = pipeline_profile.get_stream(RS2_STREAM_DEPTH);
-    streams_.push_back(stream.as<rs2::video_stream_profile>());
-
-    printf("Depth calibration (%s):\n", streams_.back().stream_name().c_str());
-
-    printf("  fx: %f, fy: %f, cx: %f, cy: %f\n",
-        streams_.back().get_intrinsics().fx,
-        streams_.back().get_intrinsics().fy,
-        streams_.back().get_intrinsics().ppx,
-        streams_.back().get_intrinsics().ppy);
-
-    printf("  distortion model type:   %d\n", (int)streams_.back().get_intrinsics().model);
-
-    printf("  distortion model params: %f %f %f %f %f\n",
-        streams_.back().get_intrinsics().coeffs[0],
-        streams_.back().get_intrinsics().coeffs[1],
-        streams_.back().get_intrinsics().coeffs[2],
-        streams_.back().get_intrinsics().coeffs[3],
-        streams_.back().get_intrinsics().coeffs[4]);
-  }
-
-  if (capture_ir0_)
-  {
-    rs2::stream_profile stream = pipeline_profile.get_stream(RS2_STREAM_INFRARED, 1);
-    streams_.push_back(stream.as<rs2::video_stream_profile>());
-  }
-
-  if (capture_ir1_)
-  {
-    rs2::stream_profile stream = pipeline_profile.get_stream(RS2_STREAM_INFRARED, 2);
-    streams_.push_back(stream.as<rs2::video_stream_profile>());
-  }
+void RealSense2Driver::CreateDepthStream()
+{
+  rs2::pipeline_profile profile = pipeline_->get_active_profile();
+  rs2::stream_profile stream = profile.get_stream(RS2_STREAM_DEPTH);
+  streams_.push_back(stream.as<rs2::video_stream_profile>());
 }
 
 

--- a/HAL/Camera/Drivers/RealSense2/RealSense2Driver.h
+++ b/HAL/Camera/Drivers/RealSense2/RealSense2Driver.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <librealsense2/rs.hpp>
+#include <HAL/Camera/CameraDriverInterface.h>
+
+namespace hal
+{
+
+class RealSense2Driver : public CameraDriverInterface
+{
+  public:
+
+    RealSense2Driver(int width, int height, int frame_rate, bool capture_color,
+        bool capture_depth, bool capture_ir0, bool capture_ir1, bool emit_ir,
+        double exposure, double gain);
+
+    virtual ~RealSense2Driver();
+
+    bool Capture(CameraMsg& images) override;
+
+    std::shared_ptr<CameraDriverInterface> GetInputDevice() override;
+
+    std::string GetDeviceProperty(const std::string& property) override;
+
+    size_t NumChannels() const override;
+
+    size_t Width(size_t index = 0) const override;
+
+    size_t Height(size_t index = 0) const override;
+
+    bool AutoExposure() const;
+
+    double Exposure() const;
+
+    void SetExposure(double exposure);
+
+    double Gain() const;
+
+    void SetGain(double gain);
+
+  private:
+
+    void Initialize();
+
+    void CreatePipeline();
+
+    void ConfigurePipeline();
+
+    void CreateStreams();
+
+  protected:
+
+    std::unique_ptr<rs2::pipeline> pipeline_;
+
+    std::vector<rs2::video_stream_profile> streams_;
+
+    int width_;
+
+    int height_;
+
+    bool capture_color_;
+
+    bool capture_depth_;
+
+    bool capture_ir0_;
+
+    bool capture_ir1_;
+
+    bool emit_ir_;
+
+    int frame_rate_;
+
+    double exposure_;
+
+    double gain_;
+};
+
+} // namespace hal

--- a/HAL/Camera/Drivers/RealSense2/RealSense2Factory.cpp
+++ b/HAL/Camera/Drivers/RealSense2/RealSense2Factory.cpp
@@ -1,0 +1,48 @@
+#include <HAL/Devices/DeviceFactory.h>
+#include "RealSense2Driver.h"
+
+namespace hal
+{
+
+class RealSense2Factory : public DeviceFactory<CameraDriverInterface>
+{
+  public:
+
+    RealSense2Factory(const std::string& name) :
+      DeviceFactory<CameraDriverInterface>(name)
+    {
+      Params() =
+      {
+        {"size", "640x480", "Capture resolution"},
+        {"fps", "30", "Capture framerate"},
+        {"rgb", "true", "Capture RGB image"},
+        {"depth", "true", "Capture Depth image"},
+        {"ir0", "false", "Capture first IR image"},
+        {"ir1", "false", "Capture second IR image"},
+        {"emitter", "true", "Enable IR emitter"},
+        {"exposure", "0", "Exposure value, 0 for auto-exposure"},
+        {"gain", "0", "Camera gain"},
+      };
+    }
+
+    std::shared_ptr<CameraDriverInterface> GetDevice(const Uri& uri)
+    {
+      ImageDim dims      = uri.properties.Get("size", ImageDim(640, 480));
+      bool capture_color = uri.properties.Get("rgb", true);
+      bool capture_depth = uri.properties.Get("depth", true);
+      bool capture_ir0   = uri.properties.Get("ir0", false);
+      bool capture_ir1   = uri.properties.Get("ir1", false);
+      bool emit_ir       = uri.properties.Get("emitter", true);
+      double exposure    = uri.properties.Get("exposure", 0.0);
+      double gain        = uri.properties.Get("gain", 0.0);
+      int fps            = uri.properties.Get("fps", 30);
+
+      return std::make_shared<RealSense2Driver>(dims.x, dims.y, fps,
+          capture_color, capture_depth, capture_ir0, capture_ir1, emit_ir,
+          exposure, gain);
+    }
+};
+
+static RealSense2Factory g_RealSenseFactory("realsense2");
+
+} // namespace hal

--- a/HAL/IMU/Drivers/Gladiator/gladiator.h
+++ b/HAL/IMU/Drivers/Gladiator/gladiator.h
@@ -2,6 +2,7 @@
 #define __GLADIATOR_H_
 
 #include <stdint.h>
+#include <HAL/Utils/TicToc.h>
 #include "ThreadedObject.h"
 #include "ThreadedCommand.h"
 #include "commport.h"

--- a/cmake_modules/FindRealSense2.cmake
+++ b/cmake_modules/FindRealSense2.cmake
@@ -1,0 +1,20 @@
+include(FindPackageHandleStandardArgs)
+
+find_path(RealSense2_INCLUDE_DIR "librealsense2/rs.h"
+  /usr/include
+  /usr/local/include
+  /opt/local/include
+)
+
+find_library(RealSense2_LIBRARIES NAMES "realsense2"
+  /usr/lib64
+  /usr/lib
+  /usr/local/lib
+  /opt/local/lib
+)
+
+find_package_handle_standard_args("RealSense2" DEFAULT_MSG
+  RealSense2_INCLUDE_DIR RealSense2_LIBRARIES)
+
+set(RealSense2_FOUND ${RealSense2_FOUND} CACHE BOOL "RealSense2 was found or not" FORCE)
+mark_as_advanced(RealSense2_INCLUDE_DIR RealSense2_LIBRARIES)


### PR DESCRIPTION
Created HAL Camera driver for the new RealSense cameras (tested with the D435). 

The HAL URI name is "realsense2" as "realsense" is already used by the previous drivers for the older camera models. The factory parameters are similar to the OpenNI2 driver, however, one can additionally capture both IR streams. Finally, IR laser strength can be set manually, or disabled completely.