### PR TITLE
updated cleave driver to copy device & system timestamps to new camer…

### DIFF
--- a/HAL/Camera/Drivers/Cleave/CleaveDriver.cpp
+++ b/HAL/Camera/Drivers/Cleave/CleaveDriver.cpp
@@ -61,12 +61,15 @@ namespace hal {
 
   bool CleaveDriver::Capture( hal::CameraMsg& vImages )
   {
-
     vImages.Clear();
     m_InMsg.Clear();
+
     if( inputCamera->Capture( m_InMsg ) == false ) {
         return false;
     }
+
+    vImages.set_device_time(m_InMsg.device_time());
+    vImages.set_system_time(m_InMsg.system_time());
 
     for( unsigned int ii = minChannel; ii <= maxChannel; ++ii ) {
       const hal::ImageMsg& InImg = m_InMsg.image(ii);


### PR DESCRIPTION
This fixes a bug in the "cleave" camera driver, which failed to copy timestamps from the captured input camera message to the cleaved output camera message. This was causing problems when trying to run vicalib with IMU data and a cleave camera stream.