### PR TITLE
fix mutex not locking

### DIFF
--- a/HAL/Camera/Drivers/Join/JoinCameraDriver.cpp
+++ b/HAL/Camera/Drivers/Join/JoinCameraDriver.cpp
@@ -41,7 +41,7 @@ void JoinCameraDriver::WorkTeam::addWorker(
 {
   const size_t workerId = m_ImageData.size();
   {
-    std::unique_lock<std::mutex>(m_Mutex);
+    std::unique_lock<std::mutex> lock(m_Mutex);
     m_ImageData.push_back(hal::CameraMsg());
     m_bWorkerDone.push_back(true);
     m_bWorkerCaptureNotOver.push_back(true);


### PR DESCRIPTION
`std::unique_lock<std::mutex>(m_Mutex);` is actually a declaration

explanation here https://youtu.be/lkgszkPnV8g?t=1771
- watch between 26:30 - 35:00